### PR TITLE
cli: Add convert subcommand and help text.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 # Test binary, built with `go test -c`
 *.test
 
+# CLI binary
+cmd/cmd
+cmd/scip
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/lsif/protocol/reader"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	"github.com/sourcegraph/scip/bindings/go/scip"
+)
+
+func convertMain(parsedArgs map[string]interface{}) error {
+	var scipReader io.Reader
+	fromPath := parsedArgs["from"].(string)
+	if fromPath == "-" {
+		scipReader = os.Stdin
+	} else if !strings.HasSuffix(fromPath, ".scip") && !strings.HasSuffix(fromPath, ".lsif-typed") {
+		return errors.Newf("expected file with .scip extension but found %s", fromPath)
+	} else {
+		scipFile, err := os.Open(fromPath)
+		defer scipFile.Close()
+		if err != nil {
+			return err
+		}
+		scipReader = scipFile
+	}
+
+	var lsifWriter io.Writer
+	toPath := parsedArgs["to"].(string)
+	if toPath == "-" {
+		lsifWriter = os.Stdout
+	} else if !strings.HasSuffix(toPath, ".lsif") {
+		return errors.Newf("expected file with .lsif extension but found %s", toPath)
+	} else {
+		lsifFile, err := os.OpenFile(toPath, os.O_WRONLY|os.O_CREATE, 0666)
+		defer lsifFile.Close()
+		if err != nil {
+			return err
+		}
+		lsifWriter = lsifFile
+	}
+
+	scipBytes, err := io.ReadAll(scipReader)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read SCIP index at path %s", fromPath)
+	}
+
+	scipIndex := scip.Index{}
+	err = proto.Unmarshal(scipBytes, &scipIndex)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse SCIP index at path %s", fromPath)
+	}
+
+	lsifIndex, err := scip.ConvertSCIPToLSIF(&scipIndex)
+	if err != nil {
+		return errors.Wrap(err, "failed to convert SCIP index to LSIF index")
+	}
+
+	err = reader.WriteNDJSON(reader.ElementsToJsonElements(lsifIndex), lsifWriter)
+	if err != nil {
+		return errors.Wrapf(err, "failed to write LSIF index to path %s", toPath)
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/bufbuild/buf v1.4.0
+	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/google/go-cmp v0.5.7
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/pseudomuto/protoc-gen-doc v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 h1:bWDMxwH3px2JBh6AyO7hdCn/PkvCZXii8TGj7sbtEbQ=
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
Makes progress towards #3.

I'm using `convert` as the subcommand name so that we don't need to
add another subcommand if/when we add support for LSIF → SCIP
conversion in the future.

I'll add a `snapshot` subcommand in a subsequent PR.

### Test plan

Added automated tests. I didn't add tests for stdin/stdout because it
felt a little cumbersome (e.g. we could pass in stdin/stdout to `convertMain`;
using different stdin/stdout in the tests) but I can add those if you think
we should test that too, NBD.