### PR TITLE
Move SCIP to LSIF conversion into library.

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -4,6 +4,11 @@
 
 - [bindings/](./bindings/): Contains a mix of generated and hand-written
   bindings for different languages.
+  - The TypeScript and Rust bindings are auto-generated.
+  - The Go bindings include protoc-generated code as well as extra
+    functionality, such as for converting a SCIP index into an LSIF index.
+    This is used by the CLI below as well as the
+    [Sourcegraph CLI](https://github.com/sourcegraph/src-cli).
 - [cmd/](./cmd/): CLI for SCIP.
   - [cmd/tests/](./cmd/tests/): Test data and packages for SCIP.
     - [cmd/tests/reprolang/](./cmd/tests/reprolang/): A verbose, small language

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,8 +7,8 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/lsif/protocol/reader"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/scip/bindings/go/scip"
 )
@@ -41,7 +41,7 @@ func main() {
 			if err != nil {
 				panic(errors.Wrapf(err, "failed to parse protobuf file '%s'", file))
 			}
-			els, err := convertSCIPToLSIF(&index)
+			els, err := scip.ConvertSCIPToLSIF(&index)
 			if err != nil {
 				panic(errors.Wrapf(err, "failed reader.ConvertSCIPIndexToLSIFIndex"))
 			}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -52,7 +52,7 @@ func TestSCIPSnapshots(t *testing.T) {
 		snapshots, err := testutil.FormatSnapshots(index, "#", symbolFormatter)
 		require.Nil(t, err)
 		index.Metadata.ProjectRoot = "file:/root"
-		lsif, err := convertSCIPToLSIF(index)
+		lsif, err := scip.ConvertSCIPToLSIF(index)
 		require.Nil(t, err)
 		var obtained bytes.Buffer
 		err = reader.WriteNDJSON(reader.ElementsToJsonElements(lsif), &obtained)


### PR DESCRIPTION
Mostly a no-op, exposing conversion functionality as a public API.

### Test plan

Existing tests are passing, double-checked that `src-cli` compiles fine
in https://github.com/sourcegraph/src-cli/pull/742 after using a replace
directive to point to my local `scip` repo with this patch.