### PR TITLE
cli: Move help text to Readme and embed Readme in CLI.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,1 @@
-# Semantic Code Intelligence Protocol (SCIP)
-
-## Contributing
-
-See [Development.md](./Development.md).
-
-Contributors should abide by the [Sourcegraph Code of Conduct](https://handbook.sourcegraph.com/company-info-and-process/communication/code_of_conduct/).
+cmd/Readme.md

--- a/cmd/Readme.md
+++ b/cmd/Readme.md
@@ -1,0 +1,39 @@
+# Semantic Code Intelligence Protocol (SCIP)
+
+<!--
+Workaround: This file is under cmd/ and symlinked from the root
+instead of being present at the root because:
+1. go:embed doesn't allow .. in embed paths.
+2. GitHub Flavored Markdown doesn't allow file inclusion.
+3. It is useful to keep the help text automatically in sync
+   between the Readme and the CLI output.
+-->
+
+## SCIP CLI reference
+
+<!-- begin usage -->
+
+```
+Usage:
+  scip convert [--from=<path>] [--to=<path>]
+  scip --version
+  scip -h | --help
+
+Options:
+  --from=<path>  Input file for conversion [default: index.scip].
+  --to=<path>    Output file for conversion [default: dump.lsif].
+  --version      Show version.
+  -h --help      Show help text.
+
+A single dash path ('-') for --from (--to) is interpreted as stdin (stdout).
+
+The 'convert' subcommand currently only supports conversion from SCIP to LSIF.
+```
+
+<!-- end usage -->
+
+## Contributing
+
+See [Development.md](./Development.md).
+
+Contributors should abide by the [Sourcegraph Code of Conduct](https://handbook.sourcegraph.com/company-info-and-process/communication/code_of_conduct/).

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,28 +1,26 @@
 package main
 
 import (
+	_ "embed"
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/docopt/docopt-go"
 )
 
-const helpText string = `Semantic Code Intelligence Protocol CLI.
+//go:embed Readme.md
+var readme string
 
-Usage:
-  scip convert [--from=<path>] [--to=<path>]
-  scip --version
-  scip -h | --help
+func helpText() string {
+	usageRegexp := regexp.MustCompile("(?s)<!-- begin usage -->\n\n```\n(.*)\n```\n\n<!-- end usage -->")
+	usageText := usageRegexp.FindStringSubmatch(readme)[1]
+	return fmt.Sprintf(helpTextTemplate, usageText)
+}
 
-Options:
-  --from=<path>  Input file for conversion [default: index.scip].
-  --to=<path>    Output file for conversion [default: dump.lsif].
-  --version      Show version.
-  -h --help      Show help text.
+const helpTextTemplate string = `Semantic Code Intelligence Protocol CLI.
 
-A single dash path ('-') for --from (--to) is interpreted as stdin (stdout).
-
-The 'convert' subcommand currently only supports conversion from SCIP to LSIF.
+%s
 
 For more details, see the project README: https://github.com/sourcegraph/scip
 `
@@ -35,7 +33,7 @@ func bailIfError(err error) {
 }
 
 func main() {
-	parsedArgs, err := docopt.ParseDoc(helpText)
+	parsedArgs, err := docopt.ParseDoc(helpText())
 	bailIfError(err)
 	// --help is handled by docopt
 	if parsedArgs["--version"].(bool) {
@@ -48,6 +46,6 @@ func main() {
 	}
 	// Normally, this should be impossible as docopt should properly handle
 	// incorrect arguments, but might as well exit nicely. 🤷🏽
-	os.Stderr.WriteString(helpText)
+	os.Stderr.WriteString(helpText())
 	os.Exit(1)
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -33,7 +33,7 @@ func TestArgumentParsing(t *testing.T) {
 	}
 	parser := docopt.Parser{SkipHelpFlags: true}
 	for _, testCase := range testCases {
-		parsedArgs, err := parser.ParseArgs(helpText, testCase.argv, "")
+		parsedArgs, err := parser.ParseArgs(helpText(), testCase.argv, "")
 		if testCase.keys == nil {
 			require.Error(t, err)
 			continue


### PR DESCRIPTION
The Readme has a comment explaining why I'm using a symlink at
the root. I've manually confirmed that GitHub will render the
Readme even if it is a symlink.

This PR is stacked on top of:
* #5 : (first commit of this PR)

### Test plan

Ran existing tests, manually ran the `--help` subcommand.