### PR TITLE
bindings/go: Fix bug in range comparison.

### DIFF
--- a/bindings/go/scip/testutil/format.go
+++ b/bindings/go/scip/testutil/format.go
@@ -152,8 +152,10 @@ func isSCIPRangeLess(a []int32, b []int32) bool {
 		return len(a) < len(b)
 	}
 	if a[2] != b[2] { // end line
-		return a[2] < b[1]
+		return a[2] < b[2]
 	}
-	// end character
-	return a[3] < b[2]
+	if len(a) == 4 {
+		return a[3] < b[3]
+	}
+	return false
 }

--- a/bindings/go/scip/testutil/format_test.go
+++ b/bindings/go/scip/testutil/format_test.go
@@ -1,0 +1,33 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsScipRangeLess(t *testing.T) {
+	testCases := []struct {
+		lhs []int32
+		rhs []int32
+	}{
+		{[]int32{0, 1, 2}, []int32{1, 0, 0}},
+		{[]int32{0, 1, 10}, []int32{0, 2, 3}},
+		{[]int32{0, 1, 2, 3}, []int32{0, 2, 4}},
+		{[]int32{0, 1, 4}, []int32{0, 1, 2, 3}},
+		{[]int32{0, 1, 2, 3}, []int32{0, 1, 4, 0}},
+		{[]int32{0, 1, 2, 3}, []int32{0, 1, 2, 4}},
+	}
+	for _, testCase := range testCases {
+		require.Truef(t, isSCIPRangeLess(testCase.lhs, testCase.rhs),
+			"%v ≮ %v", testCase.lhs, testCase.rhs)
+		require.Falsef(t, isSCIPRangeLess(testCase.rhs, testCase.lhs),
+			"%v < %v", testCase.rhs, testCase.lhs)
+
+		require.Falsef(t, isSCIPRangeLess(testCase.lhs, testCase.lhs),
+			"%v < %v", testCase.lhs, testCase.lhs)
+		require.Falsef(t, isSCIPRangeLess(testCase.lhs, testCase.lhs),
+			"%v < %v", testCase.rhs, testCase.rhs)
+	}
+
+}


### PR DESCRIPTION
The old code does incorrect index comparisons and can also cause
out-of-bounds indexing when both source ranges are identical.

### Test plan

Added unit tests.