### PR TITLE
Add `scip snapshot` subcommand

### DIFF
--- a/bindings/go/scip/symbol_formatter.go
+++ b/bindings/go/scip/symbol_formatter.go
@@ -13,6 +13,15 @@ type SymbolFormatter struct {
 	IncludeDescriptor     func(descriptor string) bool
 }
 
+// VerboseSymbolFormatter formats all parts of the symbol.
+var VerboseSymbolFormatter = SymbolFormatter{
+	IncludeScheme:         func(scheme string) bool { return true },
+	IncludePackageManager: func(_unused string) bool { return true },
+	IncludePackageName:    func(_unused string) bool { return true },
+	IncludePackageVersion: func(_unused string) bool { return true },
+	IncludeDescriptor:     func(_unused string) bool { return true },
+}
+
 // DescriptorOnlyFormatter formats only the descriptor part of the symbol.
 var DescriptorOnlyFormatter = SymbolFormatter{
 	IncludeScheme:         func(scheme string) bool { return scheme == "local" },

--- a/cmd/Readme.md
+++ b/cmd/Readme.md
@@ -16,6 +16,7 @@ instead of being present at the root because:
 ```
 Usage:
   scip convert [--from=<path>] [--to=<path>]
+  scip stats [--from=<path>]
   scip --version
   scip -h | --help
 

--- a/cmd/Readme.md
+++ b/cmd/Readme.md
@@ -17,14 +17,16 @@ instead of being present at the root because:
 Usage:
   scip convert [--from=<path>] [--to=<path>]
   scip stats [--from=<path>]
+  scip snapshot [--from=<path>] [--output=<path>]
   scip --version
   scip -h | --help
 
 Options:
-  --from=<path>  Input file for conversion [default: index.scip].
-  --to=<path>    Output file for conversion [default: dump.lsif].
-  --version      Show version.
-  -h --help      Show help text.
+  --from=<path>   Input file for conversion [default: index.scip].
+  --to=<path>     Output file for conversion [default: dump.lsif].
+  --output=<path> Output directory [default: scip-snapshot].
+  --version       Show version.
+  -h --help       Show help text.
 
 A single dash path ('-') for --from (--to) is interpreted as stdin (stdout).
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,6 +44,10 @@ func main() {
 		bailIfError(convertMain(parsedArgs))
 		os.Exit(0)
 	}
+	if parsedArgs["stats"].(bool) {
+		bailIfError(statsMain(parsedArgs))
+		os.Exit(0)
+	}
 	// Normally, this should be impossible as docopt should properly handle
 	// incorrect arguments, but might as well exit nicely. 🤷🏽
 	os.Stderr.WriteString(helpText())

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,6 +48,10 @@ func main() {
 		bailIfError(statsMain(parsedArgs))
 		os.Exit(0)
 	}
+	if parsedArgs["snapshot"].(bool) {
+		bailIfError(snapshotMain(parsedArgs))
+		os.Exit(0)
+	}
 	// Normally, this should be impossible as docopt should properly handle
 	// incorrect arguments, but might as well exit nicely. 🤷🏽
 	os.Stderr.WriteString(helpText())

--- a/cmd/option_from.go
+++ b/cmd/option_from.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/sourcegraph/scip/bindings/go/scip"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"google.golang.org/protobuf/proto"
+)
+
+// readFromOptions reads the fromPath parameter into a SCIP Index message.
+// If fromPath has the value "-" then the SCIP Index is read from os.Stdin.
+// Otherwise, fromPath is interpreted as a file path and the bytes are read from disk.
+func readFromOption(fromPath string) (*scip.Index, error) {
+	var scipReader io.Reader
+	if fromPath == "-" {
+		scipReader = os.Stdin
+	} else if !strings.HasSuffix(fromPath, ".scip") && !strings.HasSuffix(fromPath, ".lsif-typed") {
+		return nil, errors.Newf("expected file with .scip extension but found %s", fromPath)
+	} else {
+		scipFile, err := os.Open(fromPath)
+		defer scipFile.Close()
+		if err != nil {
+			return nil, err
+		}
+		scipReader = scipFile
+	}
+
+	scipBytes, err := io.ReadAll(scipReader)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read SCIP index at path %s", fromPath)
+	}
+
+	scipIndex := scip.Index{}
+	err = proto.Unmarshal(scipBytes, &scipIndex)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse SCIP index at path %s", fromPath)
+	}
+	return &scipIndex, nil
+}

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sourcegraph/scip/bindings/go/scip"
+	"github.com/sourcegraph/scip/bindings/go/scip/testutil"
+)
+
+func snapshotMain(parsedArgs map[string]interface{}) error {
+	from := parsedArgs["--from"].(string)
+	index, err := readFromOption(from)
+	if err != nil {
+		return err
+	}
+	output := parsedArgs["--output"].(string)
+	err = os.RemoveAll(output)
+	if err != nil {
+		return err
+	}
+	snapshots, err := testutil.FormatSnapshots(index, "//", scip.VerboseSymbolFormatter)
+	if err != nil {
+		return err
+	}
+	for _, snapshot := range snapshots {
+		outputPath := filepath.Join(output, snapshot.RelativePath)
+		err = os.MkdirAll(filepath.Dir(outputPath), 0755)
+		if err != nil {
+			return err
+		}
+		err = os.WriteFile(outputPath, []byte(snapshot.Text), 0755)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Println("done: " + output)
+	return nil
+}

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path/filepath"
+
+	"github.com/hhatto/gocloc"
+	"github.com/sourcegraph/scip/bindings/go/scip"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func statsMain(parsedArgs map[string]interface{}) error {
+	from := parsedArgs["--from"].(string)
+	index, err := readFromOption(from)
+	if err != nil {
+		return err
+	}
+	if index.Metadata == nil {
+		return errors.Errorf("Index.Metadata is nil (--from=%s)", from)
+	}
+	output := map[string]interface{}{}
+	indexStats, err := countStatistics(index)
+	if err != nil {
+		return err
+	}
+	jsonBytes, err := json.MarshalIndent(indexStats, "", "  ")
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshall into JSON %s", output)
+	}
+	fmt.Println(string(jsonBytes))
+	return nil
+}
+
+type indexStatistics struct {
+	Documents   int32 `json:"documents"`
+	LinesOfCode int32 `json:"linesOfCode"`
+	Occurrences int32 `json:"occurrences"`
+	Definitions int32 `json:"definitions"`
+}
+
+func countStatistics(index *scip.Index) (*indexStatistics, error) {
+	loc, err := countLinesOfCode(index)
+	if err != nil {
+		return nil, err
+	}
+	stats := &indexStatistics{
+		Documents:   int32(len(index.Documents)),
+		LinesOfCode: loc.Total.Code,
+		Occurrences: 0,
+		Definitions: 0,
+	}
+	for _, document := range index.Documents {
+		for _, occurrence := range document.Occurrences {
+			stats.Occurrences += 1
+			if occurrence.SymbolRoles&int32(scip.SymbolRole_Definition) > 0 {
+				stats.Definitions += 1
+			}
+		}
+	}
+	return stats, nil
+}
+
+func countLinesOfCode(index *scip.Index) (*gocloc.Result, error) {
+	root, err := url.Parse(index.Metadata.ProjectRoot)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse Index.Metadata.ProjectRoot as a URI %s", index.Metadata.ProjectRoot)
+	}
+	processor := gocloc.NewProcessor(gocloc.NewDefinedLanguages(), gocloc.NewClocOptions())
+	var paths []string
+	for _, document := range index.Documents {
+		paths = append(paths, filepath.Join(root.Path, document.RelativePath))
+	}
+	return processor.Analyze(paths)
+}

--- a/go.mod
+++ b/go.mod
@@ -26,16 +26,20 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.3.0-java // indirect
 	github.com/getsentry/sentry-go v0.12.0 // indirect
+	github.com/go-enry/go-enry/v2 v2.7.2 // indirect
+	github.com/go-enry/go-oniguruma v1.2.1 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/hhatto/gocloc v0.4.2 // indirect
 	github.com/huandu/xstrings v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.4 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a // indirect
+	github.com/jessevdk/go-flags v1.4.0 // indirect
 	github.com/jhump/protocompile v0.0.0-20220216033700-d705409f108f // indirect
 	github.com/jhump/protoreflect v1.12.1-0.20220417024638-438db461d753 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,10 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
+github.com/go-enry/go-enry/v2 v2.7.2 h1:IBtFo783PgL7oyd/TL1/8HQFMNzOAl4NaLPbzNOvbwM=
+github.com/go-enry/go-enry/v2 v2.7.2/go.mod h1:GVzIiAytiS5uT/QiuakK7TF1u4xDab87Y8V5EJRpsIQ=
+github.com/go-enry/go-oniguruma v1.2.1 h1:k8aAMuJfMrqm/56SG2lV9Cfti6tC4x8673aHCcBk+eo=
+github.com/go-enry/go-oniguruma v1.2.1/go.mod h1:bWDhYP+S6xZQgiRL7wlTScFYBe023B6ilRZbCAD5Hf4=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
@@ -145,6 +149,8 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/hhatto/gocloc v0.4.2 h1:deh3Xb1uqiySNgOccMNYb3HbKsUoQDzsZRpfQmbTIhs=
+github.com/hhatto/gocloc v0.4.2/go.mod h1:YsPWNgXpEHv+5NAEMGlVIX1hkVypLp+b0AEB8T1NRfA=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.0.0 h1:pO2K/gKgKaat5LdpAhxhluX2GPQMaI3W5FUz/I/UnWk=
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
@@ -163,6 +169,8 @@ github.com/iris-contrib/pongo2 v0.0.1/go.mod h1:Ssh+00+3GAZqSQb30AvBRNxBx7rf0Gqw
 github.com/iris-contrib/schema v0.0.1/go.mod h1:urYA3uvUNG1TIIjOSCzHr9/LmbQo8LrOcOqfqxa4hXw=
 github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a h1:d4+I1YEKVmWZrgkt6jpXBnLgV2ZjO0YxEtLDdfIZfH4=
 github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a/go.mod h1:Zi/ZFkEqFHTm7qkjyNJjaWH4LQA9LQhGJyF0lTYGpxw=
+github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/gopoet v0.0.0-20190322174617-17282ff210b3/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/gopoet v0.1.0/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/goprotoc v0.5.0/go.mod h1:VrbvcYrQOrTi3i0Vf+m+oqQWk9l72mjkJCYo7UvLHRQ=
@@ -289,6 +297,7 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/sourcegraph/sourcegraph/lib v0.0.0-20220511160847-5a43d3ea24eb h1:D8ciD0FEcPNnVm6BC8vg7gWJ9VxoJe6k/4j+Qxparj0=
 github.com/sourcegraph/sourcegraph/lib v0.0.0-20220511160847-5a43d3ea24eb/go.mod h1:iFiGPqnhOvQziDZkpWasU+Uo1BaEt/Au9kNK4VpqyOw=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=


### PR DESCRIPTION
### Test plan

Manually ran `scip snapshot` against an example index. We're already using the same snapshot logic for reprolang tests so if we want to test this PR it would have to be by invoking the cli directly.
