### PR TITLE
ci: Run prettier for JSON only changes.

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -8,6 +8,7 @@ on:
       - '**.yml'
       - '**.yaml'
       - '**.js'
+      - '**.json'
       - '**.ts'
 
 jobs:


### PR DESCRIPTION
Renovate managed to bypass the formatting check earlier because the formatting check
didn't trigger for JSON only changes.

### Test plan

n/a