### PR TITLE
ci: Give workflow jobs more useful names.

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -9,7 +9,7 @@ on:
       - '**/go.sum'
 
 jobs:
-  check:
+  go-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -7,7 +7,7 @@ on:
       - '**.cabal'
 
 jobs:
-  ci:
+  haskell-typecheck:
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -10,7 +10,7 @@ on:
       - 'buf**'
 
 jobs:
-  check:
+  protoc-gen-up-to-date:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/reprolang.yml
+++ b/.github/workflows/reprolang.yml
@@ -7,7 +7,7 @@ on:
       - 'reprolang/**'
 
 jobs:
-  check:
+  reprolang-parser-up-to-date:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
       - '**/Cargo.lock'
 
 jobs:
-  check:
+  rust-typecheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -10,7 +10,7 @@ on:
       - '**/yarn.lock'
 
 jobs:
-  check:
+  typescript-typecheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The names show up in the UI, and having a bunch of jobs all
named 'check' makes it impossible to distinguish which job
is being referred to.

![PR jobs as seen after merging](https://user-images.githubusercontent.com/93103176/170079268-3c5dd81f-f872-4eca-a45e-36302dfe07e6.png)


### Test plan

n/a
