### PR TITLE
Fix a bug related to textDocumentation/implementation

### DIFF
--- a/cmd/tests/snapshots/input/implementation/animal.repro
+++ b/cmd/tests/snapshots/input/implementation/animal.repro
@@ -1,3 +1,4 @@
 # Test how to implement a symbol within the same workspace.
 definition animal#
 definition dog# implements animal#
+definition cat# implements animal#

--- a/cmd/tests/snapshots/output/implementation/animal.repro
+++ b/cmd/tests/snapshots/output/implementation/animal.repro
@@ -7,4 +7,9 @@
 #           documentation signature of dog#
 #           relationship animal.repro/animal# implementation
 #                           ^^^^^^^ reference animal.repro/animal#
+ definition cat# implements animal#
+#           ^^^^ definition animal.repro/cat#
+#           documentation signature of cat#
+#           relationship animal.repro/animal# implementation
+#                           ^^^^^^^ reference animal.repro/animal#
  

--- a/cmd/tests/snapshots/output/implementation/dump.lsif
+++ b/cmd/tests/snapshots/output/implementation/dump.lsif
@@ -54,11 +54,9 @@
 {"id":54,"type":"vertex","label":"range","start":{"line":3,"character":11},"end":{"line":3,"character":15}}
 {"id":55,"type":"edge","label":"next","inV":14,"outV":54}
 {"id":56,"type":"edge","label":"item","inVs":[54],"outV":13,"document":33}
-{"id":57,"type":"vertex","label":"implementationResult"}
-{"id":58,"type":"edge","label":"textDocument/implementation","inV":57,"outV":3}
-{"id":59,"type":"edge","label":"item","inVs":[54],"outV":57,"document":33}
-{"id":60,"type":"edge","label":"item","inVs":[54],"outV":15,"document":33}
-{"id":61,"type":"vertex","label":"range","start":{"line":3,"character":27},"end":{"line":3,"character":34}}
-{"id":62,"type":"edge","label":"next","inV":3,"outV":61}
-{"id":63,"type":"edge","label":"item","inVs":[61],"outV":4,"document":33}
-{"id":64,"type":"edge","label":"contains","inVs":[34,44,51,54,61],"outV":33}
+{"id":57,"type":"edge","label":"item","inVs":[54],"outV":47,"document":33}
+{"id":58,"type":"edge","label":"item","inVs":[54],"outV":15,"document":33}
+{"id":59,"type":"vertex","label":"range","start":{"line":3,"character":27},"end":{"line":3,"character":34}}
+{"id":60,"type":"edge","label":"next","inV":3,"outV":59}
+{"id":61,"type":"edge","label":"item","inVs":[59],"outV":4,"document":33}
+{"id":62,"type":"edge","label":"contains","inVs":[34,44,51,54,59],"outV":33}

--- a/cmd/tests/snapshots/output/implementation/dump.lsif
+++ b/cmd/tests/snapshots/output/implementation/dump.lsif
@@ -13,29 +13,52 @@
 {"id":13,"type":"vertex","label":"definitionResult"}
 {"id":14,"type":"vertex","label":"resultSet"}
 {"id":15,"type":"vertex","label":"referenceResult"}
-{"id":16,"type":"vertex","label":"hoverResult","result":{"contents":{"kind":"markdown","value":"signature of dog#"}}}
+{"id":16,"type":"vertex","label":"hoverResult","result":{"contents":{"kind":"markdown","value":"signature of cat#"}}}
 {"id":17,"type":"edge","label":"textDocument/definition","inV":13,"outV":14}
 {"id":18,"type":"edge","label":"textDocument/references","inV":15,"outV":14}
 {"id":19,"type":"edge","label":"textDocument/hover","inV":16,"outV":14}
-{"id":20,"type":"vertex","label":"moniker","identifier":"reprolang repro_manager implementation 1.0.0 animal.repro/dog#","kind":"export","scheme":"reprolang"}
+{"id":20,"type":"vertex","label":"moniker","identifier":"reprolang repro_manager implementation 1.0.0 animal.repro/cat#","kind":"export","scheme":"reprolang"}
 {"id":21,"type":"edge","label":"moniker","inV":20,"outV":14}
 {"id":22,"type":"edge","label":"packageInformation","inV":11,"outV":20}
-{"id":23,"type":"vertex","label":"document","uri":"file:/root/animal.repro"}
-{"id":24,"type":"vertex","label":"range","start":{"line":1,"character":11},"end":{"line":1,"character":18}}
-{"id":25,"type":"edge","label":"next","inV":3,"outV":24}
-{"id":26,"type":"edge","label":"item","inVs":[24],"outV":2,"document":23}
-{"id":27,"type":"vertex","label":"implementationResult"}
-{"id":28,"type":"edge","label":"textDocument/implementation","inV":27,"outV":14}
-{"id":29,"type":"edge","label":"item","inVs":[24],"outV":27,"document":23}
-{"id":30,"type":"edge","label":"item","inVs":[24],"outV":4,"document":23}
-{"id":31,"type":"vertex","label":"range","start":{"line":2,"character":11},"end":{"line":2,"character":15}}
-{"id":32,"type":"edge","label":"next","inV":14,"outV":31}
-{"id":33,"type":"edge","label":"item","inVs":[31],"outV":13,"document":23}
-{"id":34,"type":"vertex","label":"implementationResult"}
-{"id":35,"type":"edge","label":"textDocument/implementation","inV":34,"outV":3}
-{"id":36,"type":"edge","label":"item","inVs":[31],"outV":34,"document":23}
-{"id":37,"type":"edge","label":"item","inVs":[31],"outV":15,"document":23}
-{"id":38,"type":"vertex","label":"range","start":{"line":2,"character":27},"end":{"line":2,"character":34}}
-{"id":39,"type":"edge","label":"next","inV":3,"outV":38}
-{"id":40,"type":"edge","label":"item","inVs":[38],"outV":4,"document":23}
-{"id":41,"type":"edge","label":"contains","inVs":[24,31,38],"outV":23}
+{"id":23,"type":"vertex","label":"definitionResult"}
+{"id":24,"type":"vertex","label":"resultSet"}
+{"id":25,"type":"vertex","label":"referenceResult"}
+{"id":26,"type":"vertex","label":"hoverResult","result":{"contents":{"kind":"markdown","value":"signature of dog#"}}}
+{"id":27,"type":"edge","label":"textDocument/definition","inV":23,"outV":24}
+{"id":28,"type":"edge","label":"textDocument/references","inV":25,"outV":24}
+{"id":29,"type":"edge","label":"textDocument/hover","inV":26,"outV":24}
+{"id":30,"type":"vertex","label":"moniker","identifier":"reprolang repro_manager implementation 1.0.0 animal.repro/dog#","kind":"export","scheme":"reprolang"}
+{"id":31,"type":"edge","label":"moniker","inV":30,"outV":24}
+{"id":32,"type":"edge","label":"packageInformation","inV":11,"outV":30}
+{"id":33,"type":"vertex","label":"document","uri":"file:/root/animal.repro"}
+{"id":34,"type":"vertex","label":"range","start":{"line":1,"character":11},"end":{"line":1,"character":18}}
+{"id":35,"type":"edge","label":"next","inV":3,"outV":34}
+{"id":36,"type":"edge","label":"item","inVs":[34],"outV":2,"document":33}
+{"id":37,"type":"vertex","label":"implementationResult"}
+{"id":38,"type":"edge","label":"textDocument/implementation","inV":37,"outV":14}
+{"id":39,"type":"edge","label":"item","inVs":[34],"outV":37,"document":33}
+{"id":40,"type":"vertex","label":"implementationResult"}
+{"id":41,"type":"edge","label":"textDocument/implementation","inV":40,"outV":24}
+{"id":42,"type":"edge","label":"item","inVs":[34],"outV":40,"document":33}
+{"id":43,"type":"edge","label":"item","inVs":[34],"outV":4,"document":33}
+{"id":44,"type":"vertex","label":"range","start":{"line":2,"character":11},"end":{"line":2,"character":15}}
+{"id":45,"type":"edge","label":"next","inV":24,"outV":44}
+{"id":46,"type":"edge","label":"item","inVs":[44],"outV":23,"document":33}
+{"id":47,"type":"vertex","label":"implementationResult"}
+{"id":48,"type":"edge","label":"textDocument/implementation","inV":47,"outV":3}
+{"id":49,"type":"edge","label":"item","inVs":[44],"outV":47,"document":33}
+{"id":50,"type":"edge","label":"item","inVs":[44],"outV":25,"document":33}
+{"id":51,"type":"vertex","label":"range","start":{"line":2,"character":27},"end":{"line":2,"character":34}}
+{"id":52,"type":"edge","label":"next","inV":3,"outV":51}
+{"id":53,"type":"edge","label":"item","inVs":[51],"outV":4,"document":33}
+{"id":54,"type":"vertex","label":"range","start":{"line":3,"character":11},"end":{"line":3,"character":15}}
+{"id":55,"type":"edge","label":"next","inV":14,"outV":54}
+{"id":56,"type":"edge","label":"item","inVs":[54],"outV":13,"document":33}
+{"id":57,"type":"vertex","label":"implementationResult"}
+{"id":58,"type":"edge","label":"textDocument/implementation","inV":57,"outV":3}
+{"id":59,"type":"edge","label":"item","inVs":[54],"outV":57,"document":33}
+{"id":60,"type":"edge","label":"item","inVs":[54],"outV":15,"document":33}
+{"id":61,"type":"vertex","label":"range","start":{"line":3,"character":27},"end":{"line":3,"character":34}}
+{"id":62,"type":"edge","label":"next","inV":3,"outV":61}
+{"id":63,"type":"edge","label":"item","inVs":[61],"outV":4,"document":33}
+{"id":64,"type":"edge","label":"contains","inVs":[34,44,51,54,61],"outV":33}


### PR DESCRIPTION
Previously, doing "Find implementations" only showed one result when there were multiple results available. Now, all available results should be shown after this fix.

Opening this as a draft since it's still not working 100% and I'm gonna continue with this PR tomorrow.

### Test plan
See newly added snapshot tests. I'm also manually testing this change by uploading the generated dump.lsif to Sourcegraph here https://sourcegraph.com/github.com/sourcegraph/scip-typescript@34337f2fa29d3a83c71814458d19741ae4f21db9/-/blob/snapshots/input/syntax/src/inheritance2.ts?L2:3&subtree=true#tab=implementations_typescript
