### PR TITLE
Correctly convert scip-typescript moniker scheme to npm

### DIFF
--- a/bindings/go/scip/convert.go
+++ b/bindings/go/scip/convert.go
@@ -282,11 +282,9 @@ func (g *graph) emitMonikerVertex(symbolID string, kind string, resultSetID int)
 		// NOTE: these special cases are needed since the Sourcegraph backend uses the "scheme" field of monikers where
 		// it should use the "manager" field of packageInformation instead.
 		switch symbol.Scheme {
-		case "lsif-java":
-		case "scip-java":
+		case "scip-java", "lsif-java":
 			scheme = "semanticdb"
-		case "scip-typescript":
-		case "lsif-typescript":
+		case "scip-typescript", "lsif-typescript":
 			scheme = "npm"
 		}
 	}


### PR DESCRIPTION
### Test plan

Manually review the diff to confirm the new behavior is desired.