### PR TITLE
fix: specify exact version in Cargo.toml

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.60.0"
 
 [dependencies]
 # Keep in sync with dev/proto-generate.sh
-protobuf = "3.0.2"
+protobuf = "=3.0.2"
 
 [lib]
 name = "rust"


### PR DESCRIPTION
Cargo only does **exact** version when you have `=` sign in front of it.

### Test plan
- [ ] yes