### PR TITLE
Use `Value` instead of `DefaultText` for default values

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -29,7 +29,7 @@ func convertCommand() cli.Command {
 				Name:        "to",
 				Usage:       "Output path for LSIF index",
 				Destination: &convertFlags.to,
-				DefaultText: "dump.lsif",
+				Value: "dump.lsif",
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -54,6 +54,6 @@ func fromFlag(storage *string) *cli.StringFlag {
 		Name:        "from",
 		Usage:       "Path to SCIP index file",
 		Destination: storage,
-		DefaultText: "index.scip",
+		Value: "index.scip",
 	}
 }

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -31,7 +31,7 @@ and symbol information.`,
 				Name:        "to",
 				Usage:       "Path to output directory for snapshot files",
 				Destination: &snapshotFlags.output,
-				DefaultText: "scip-snapshot",
+				Value: "scip-snapshot",
 			},
 		},
 		Action: func(c *cli.Context) error {


### PR DESCRIPTION
Previously, the default value was unset because we only configured the
"(default: X)" --help message.

### Test plan
I manually tested the change since we don't have integration tests yet.