### PR TITLE
bindings/go: Fix hang in snapshot generation.

### DIFF
--- a/bindings/go/scip/testutil/format.go
+++ b/bindings/go/scip/testutil/format.go
@@ -82,6 +82,7 @@ func FormatSnapshot(
 			occ := document.Occurrences[i]
 			pos := scip.NewRange(occ.Range)
 			if !pos.IsSingleLine() {
+				i++
 				continue
 			}
 			b.WriteString(commentSyntax)


### PR DESCRIPTION
Fixes #55.

### Test plan

Manually tested with the ill-formed index.