### PR TITLE
Avoid gitignore applying to bindings/go/scip.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 # CLI binary
 cmd/cmd
 cmd/scip
-scip
+/scip
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out


### PR DESCRIPTION

### Test plan

n/a