### PR TITLE
fix: SCIP documents may be empty.

### DIFF
--- a/bindings/go/scip/convert.go
+++ b/bindings/go/scip/convert.go
@@ -241,7 +241,9 @@ func (g *graph) emitDocument(index *Index, doc *Document) {
 		// reference
 		g.emitEdge("item", reader.Edge{OutV: resultIDs.ReferenceResult, InVs: []int{rangeID}, Document: documentID})
 	}
-	g.emitEdge("contains", reader.Edge{OutV: documentID, InVs: rangeIDs})
+	if len(rangeIDs) != 0 { // a document may be empty
+		g.emitEdge("contains", reader.Edge{OutV: documentID, InVs: rangeIDs})
+	}
 }
 
 // emitRelationships emits "referenceResults" and "implementationResult" based on the value of scip.SymbolInformation.Relationships


### PR DESCRIPTION
Don't crash if that's the case.
See the index in https://github.com/sourcegraph/scip/issues/68.

### Test plan

Tested with an index generated by scip-ruby.