### PR TITLE
Add github repository link

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 description = """
 SCIP (pronunciation: "skip") is a language-agnostic protocol for indexing source code, which can be used to power code navigation functionality such as Go to definition, Find references, and Find implementations.
 """
+repository = "https://github.com/sourcegraph/scip"
 
 # We need >= 1.60.0 because the generated code uses
 # https://doc.rust-lang.org/std/vec/struct.Vec.html#method.spare_capacity_mut


### PR DESCRIPTION
Repository links are useful if you want to figure out where a particular crate is hosted. I have wondered the same thing and was able to find this repository, but it would have been easier if I could just have clicked the link on docs.rs.