### PR TITLE
reprolang: Add flag to use abspaths in LSIF indexes.

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -42,3 +42,24 @@ Protobuf output can be inspected using `protoc`:
 ```
 protoc --decode=scip.Index -I /path/to/scip scip.proto < index.scip
 ```
+
+## Testing and adding new SCIP semantics
+
+It is helpful to use reprolang to check the existing code navigation behavior,
+to design new code navigation behavior,
+or to investigate the effect of the SCIP to LSIF desugaring.
+The LSIF index for reprolang code is much smaller,
+which aids debugging.
+
+To do this, add a test file (and implement any new functionality) first.
+Then, regenerate the LSIF index with absolute paths.
+
+```bash
+go test ./cmd -update-snapshots -debug-snapshot-abspaths
+```
+
+The LSIF index can be uploaded to a local Sourcegraph instance using:
+
+```bash
+PACKAGE=MY_PACKAGE_NAME SRC_ACCESS_TOKEN=MY_TOKEN SRC_ENDPOINT=https://sourcegraph.test:3443 src code-intel upload -file="cmd/tests/snapshots/output/$PACKAGE/dump.lsif" -root="cmd/tests/snapshots/input/$PACKAGE"
+```

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -50,6 +51,8 @@ func TestReadmeInSync(t *testing.T) {
 	}
 }
 
+var debugSnapshotAbspaths = flag.Bool("debug-snapshot-abspaths", false, "use absolute paths in snapshot outputs, useful for making uploads to test code navigation")
+
 // TestSCIPSnapshots runs all the snapshot tests.
 func TestSCIPSnapshots(t *testing.T) {
 	cwd, err := os.Getwd()
@@ -86,7 +89,13 @@ func TestSCIPSnapshots(t *testing.T) {
 		symbolFormatter.IncludePackageName = func(name string) bool { return name != testName }
 		snapshots, err := testutil.FormatSnapshots(index, "#", symbolFormatter)
 		require.Nil(t, err)
-		index.Metadata.ProjectRoot = "file:/root"
+		if debugSnapshotAbspaths != nil && *debugSnapshotAbspaths {
+			inputDirAbsPath, err := filepath.Abs(inputDirectory)
+			require.Nil(t, err)
+			index.Metadata.ProjectRoot = inputDirAbsPath
+		} else {
+			index.Metadata.ProjectRoot = "file:/root"
+		}
 		lsif, err := scip.ConvertSCIPToLSIF(index)
 		require.Nil(t, err)
 		var obtained bytes.Buffer


### PR DESCRIPTION
Based on convo in Zoom, this should help test code nav behavior quickly compared to having to replace strings manually.

### Test plan

Tested this locally.