### PR TITLE
cli: Add lint subcommand.

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -50,6 +50,14 @@ and can be inspected using `protoc`:
 protoc --decode=scip.Index -I /path/to/scip scip.proto < index.scip
 ```
 
+There is also a `lint` subcommand which performs various well-formedness
+checks on a SCIP index. It is meant primarily for people working on a SCIP indexer,
+and is not recommended for use in other settings.
+
+```
+scip lint /path/to/index.scip
+```
+
 ## Testing and adding new SCIP semantics
 
 It is helpful to use reprolang to check the existing code navigation behavior,

--- a/Readme.md
+++ b/Readme.md
@@ -70,9 +70,10 @@ DESCRIPTION:
 
 COMMANDS:
    convert   Convert a SCIP index to an LSIF index
+   lint      Flag potential issues with a SCIP index
+   print     Print a SCIP index in a human-readable format for debugging
    snapshot  Generate snapshot files for golden testing
    stats     Output useful statistics about a SCIP index
-   print     Print a SCIP index in a human-readable format for debugging
    help, h   Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
@@ -105,9 +106,9 @@ USAGE:
 
 DESCRIPTION:
    Example usage:
-   
+
      scip lint /path/to/index.scip
-   
+
    You may want to filter the output using `grep -v <pattern>`
    to narrow down on certain classes of errors.
 

--- a/Readme.md
+++ b/Readme.md
@@ -94,6 +94,27 @@ OPTIONS:
    --to value    Output path for LSIF index (default: dump.lsif)
 ```
 
+### `scip lint`
+
+```
+NAME:
+   scip lint - Flag potential issues with a SCIP index
+
+USAGE:
+   scip lint [command options] [arguments...]
+
+DESCRIPTION:
+   Example usage:
+   
+     scip lint /path/to/index.scip
+   
+   You may want to filter the output using `grep -v <pattern>`
+   to narrow down on certain classes of errors.
+
+OPTIONS:
+   --help, -h  show help (default: false)
+```
+
 ### `scip print`
 
 ```

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -1,0 +1,396 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/scip/bindings/go/scip"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func lintCommand() cli.Command {
+	snapshot := cli.Command{
+		Name:  "lint",
+		Usage: "Flag potential issues with a SCIP index",
+		Description: "Example usage:\n\n  scip lint /path/to/index.scip\n\n" +
+			"You may want to filter the output using `grep -v <pattern>`\n" +
+			"to narrow down on certain classes of errors.",
+		Action: func(c *cli.Context) error {
+			indexPath := c.Args().Get(0)
+			if indexPath == "" {
+				return errors.New("missing argument for path to SCIP index")
+			}
+			return lintMain(indexPath)
+		},
+	}
+	return snapshot
+}
+
+func lintMain(indexPath string) error {
+	scipIndex, err := readFromOption(indexPath)
+	if err != nil {
+		return err
+	}
+
+	symTable := newSymbolTable()
+
+	var errs errorSet
+
+	for _, extSym := range scipIndex.ExternalSymbols {
+		if extSym.Symbol == "" {
+			errs.Add(emptyStringError{what: "symbol", context: "external symbols"})
+		} else if !symTable.extSyms.Add(extSym.Symbol) {
+			errs.Add(duplicateSymbolInfoWarning{symbol: extSym.Symbol})
+		}
+	}
+
+	docMap := map[string]*scip.Document{}
+	for _, doc := range scipIndex.Documents {
+		if doc.RelativePath == "" {
+			errs.Add(emptyStringError{what: "document", context: "index"})
+			errs.Add(note{"empty documents will be skipped for diagnostics"})
+			continue
+		}
+		if _, ok := docMap[doc.RelativePath]; ok {
+			errs.Add(duplicateDocumentWarning{path: doc.RelativePath})
+			errs.Add(note{"out of documents with identical paths, all but one will be skipped for diagnostics"})
+		} else {
+			docMap[doc.RelativePath] = doc
+		}
+	}
+
+	for path, doc := range docMap {
+		for _, sym := range doc.Symbols {
+			if err := symTable.addFileForSymbol(sym.Symbol, path); err != nil {
+				errs.Add(err)
+			}
+		}
+		for _, sym := range doc.Symbols {
+			for _, rel := range sym.Relationships {
+				// This has to run in a second pass so that all symbols are first populated.
+				if err := symTable.addRelationship(sym.Symbol, path, rel); err != nil {
+					errs.Add(err)
+				}
+			}
+		}
+	}
+
+	for _, extSym := range scipIndex.ExternalSymbols {
+		for _, rel := range extSym.Relationships {
+			if err := symTable.addRelationshipForExternalSymbol(extSym.Symbol, rel); err != nil {
+				errs.Add(err)
+			}
+		}
+	}
+
+	for path, doc := range docMap {
+		for _, occ := range doc.Occurrences {
+			if err := symTable.addOccurrence(path, occ); err != nil {
+				errs.Add(err)
+			}
+		}
+	}
+
+	var errOut errors.MultiError
+	errOut = errors.Append(errOut, errs.Unique()...)
+	return errOut
+}
+
+// --- Main types ---
+
+type occurrenceKey struct {
+	loc   scip.Range
+	roles int32
+}
+
+func scipOccurrenceKey(occ *scip.Occurrence) occurrenceKey {
+	return occurrenceKey{*scip.NewRange(occ.Range), occ.SymbolRoles}
+}
+
+type occurrenceMap = map[occurrenceKey]*scip.Occurrence
+
+type fileOccurrenceMap = map[string]occurrenceMap
+
+type symbolTable struct {
+	extSyms      set[string]
+	localSymsMap map[string]fileOccurrenceMap
+	relsMap      set[pair[string]]
+}
+
+func newSymbolTable() symbolTable {
+	return symbolTable{
+		newSet[string](),
+		map[string]fileOccurrenceMap{},
+		newSet[pair[string]](),
+	}
+}
+
+func (st *symbolTable) addFileForSymbol(sym string, path string) error {
+	if sym == "" {
+		return emptyStringError{what: "symbol", context: fmt.Sprintf("symbols for document %s", path)}
+	}
+	if st.extSyms.Contains(sym) {
+		return bothLocalAndExternalSymbolError{sym, path}
+	}
+	if occsForSym, ok := st.localSymsMap[sym]; ok {
+		if _, ok := occsForSym[path]; ok {
+			return duplicateSymbolInfoWarning{symbol: sym, path: path}
+		} else {
+			occsForSym[path] = occurrenceMap{}
+		}
+	} else {
+		st.localSymsMap[sym] = fileOccurrenceMap{path: {}}
+	}
+	return nil
+}
+
+func (st *symbolTable) addRelationshipForExternalSymbol(sym string, rel *scip.Relationship) error {
+	if sym == "" { // Errors for this are emitted earlier
+		return nil
+	}
+	if rel.Symbol == "" {
+		return emptyStringError{what: "symbol", context: fmt.Sprintf("relationships for external symbol %s", sym)}
+	}
+	if !rel.IsDefinition && !rel.IsReference && !rel.IsImplementation && !rel.IsTypeDefinition {
+		return missingRelationshipFlagError{sym, "external symbols"}
+	}
+	if !st.extSyms.Contains(rel.Symbol) {
+		return missingSymbolInRelationshipError{sym, "external symbols", rel.Symbol, "external symbols"}
+	}
+	relPair := pair[string]{sym, rel.Symbol}
+	if st.relsMap.Contains(relPair) {
+		return multipleRelationshipWarning{sym, rel.Symbol}
+	}
+	st.relsMap.Add(relPair)
+	return nil
+}
+
+func (st *symbolTable) addRelationship(sym string, path string, rel *scip.Relationship) error {
+	if sym == "" { // Errors for this are emitted earlier
+		return nil
+	}
+	if rel.Symbol == "" {
+		return emptyStringError{what: "symbol", context: fmt.Sprintf("relationships for %s", sym)}
+	}
+	if !rel.IsDefinition && !rel.IsReference && !rel.IsImplementation && !rel.IsTypeDefinition {
+		return missingRelationshipFlagError{sym, fmt.Sprintf("symbols for file %s", path)}
+	}
+	if !st.extSyms.Contains(rel.Symbol) {
+		if _, ok := st.localSymsMap[rel.Symbol]; !ok {
+			return missingSymbolInRelationshipError{sym, fmt.Sprintf("symbols for file %s", path), rel.Symbol, "external symbols or some other file"}
+		}
+	}
+	relPair := pair[string]{sym, rel.Symbol}
+	if st.relsMap.Contains(relPair) {
+		return multipleRelationshipWarning{sym, rel.Symbol}
+	}
+	st.relsMap.Add(relPair)
+	return nil
+}
+
+func (st *symbolTable) addOccurrence(path string, occ *scip.Occurrence) error {
+	if occ.Symbol == "" {
+		return emptyStringError{what: "symbol", context: fmt.Sprintf("occurrence at %s @ %s", path, scipRangeToString(*scip.NewRange(occ.Range)))}
+	}
+	if st.extSyms.Contains(occ.Symbol) {
+		return nil
+	}
+	if occMap, ok := st.localSymsMap[occ.Symbol]; ok {
+		occKey := scipOccurrenceKey(occ)
+		if occs, ok := occMap[path]; ok {
+			if matchingOcc, ok := occs[occKey]; ok {
+				return duplicateOccurrenceWarning{matchingOcc, occ, path}
+			} else {
+				occs[occKey] = occ
+			}
+		} else {
+			// We're seeing an occurrence for a symbol in a file
+			// other than the one it was defined in.
+			occMap[path] = occurrenceMap{occKey: occ}
+		}
+	} else {
+		return missingSymbolForOccurrenceError{occ.Symbol, path, *scip.NewRange(occ.Range)}
+	}
+	return nil
+}
+
+// --- SCIP related utilities ---
+
+func scipRangeToString(r scip.Range) string {
+	return fmt.Sprintf("%d:%d-%d:%d", r.Start.Line, r.Start.Character, r.End.Line, r.End.Character)
+}
+
+// --- All possible errors ---
+
+type duplicateSymbolInfoWarning struct {
+	symbol string
+	// path may be empty for external symbols
+	path string
+}
+
+func (e duplicateSymbolInfoWarning) Error() string {
+	if e.path == "" {
+		return fmt.Sprintf("warning: found repeated SymbolInformation for '%s' in '%s'", e.symbol, e.path)
+	}
+	return fmt.Sprintf("warning: found repeated SymbolInformation for external symbol '%s'", e.symbol)
+}
+
+type emptyStringError struct {
+	what    string
+	context string
+}
+
+func (e emptyStringError) Error() string {
+	return fmt.Sprintf("error: found empty %s in %s", e.what, e.context)
+}
+
+type duplicateDocumentWarning struct {
+	path string
+}
+
+func (e duplicateDocumentWarning) Error() string {
+	return fmt.Sprintf("warning: found multiple documents with path '%s' in index", e.path)
+}
+
+type bothLocalAndExternalSymbolError struct {
+	symbol string
+	path   string
+}
+
+func (e bothLocalAndExternalSymbolError) Error() string {
+	return fmt.Sprintf("error: SymbolInformation for '%s'"+
+		" is present in both external symbols and document '%s'", e.symbol, e.path)
+}
+
+type missingRelationshipFlagError struct {
+	symbol  string
+	context string
+}
+
+func (e missingRelationshipFlagError) Error() string {
+	return fmt.Sprintf("error: at least one of is_definition,"+
+		" is_reference, is_type_definition or is_implementation should"+
+		" be set for symbol '%s' in %s", e.symbol, e.context)
+}
+
+type missingSymbolInRelationshipError struct {
+	symbol                       string
+	symbolContext                string
+	relatedSymbol                string
+	expectedRelatedSymbolContext string
+}
+
+func (e missingSymbolInRelationshipError) Error() string {
+	return fmt.Sprintf("error: symbol '%s' (#1) (in %s) has"+
+		" a relationship to '%s' (#2), but couldn't find #2 in %s",
+		e.symbol, e.symbolContext, e.relatedSymbol, e.expectedRelatedSymbolContext)
+}
+
+type multipleRelationshipWarning struct {
+	symbol        string
+	relatedSymbol string
+}
+
+func (e multipleRelationshipWarning) Error() string {
+	return fmt.Sprintf("warning: found multiple relationships from"+
+		" '%s' to '%s', which could optimized into a single relationship", e.symbol, e.relatedSymbol)
+}
+
+type missingSymbolForOccurrenceError struct {
+	symbol string
+	path   string
+	occ    scip.Range
+}
+
+func (e missingSymbolForOccurrenceError) Error() string {
+	return fmt.Sprintf("error: found occurrence at %s @ %s"+
+		" for symbol %s, but there is no matching SymbolInformation"+
+		" in external symbols or any document", e.path, scipRangeToString(e.occ), e.symbol)
+}
+
+type duplicateOccurrenceWarning struct {
+	occ1 *scip.Occurrence
+	occ2 *scip.Occurrence
+	path string
+}
+
+func (e duplicateOccurrenceWarning) Error() string {
+	return fmt.Sprintf("warning: found duplicate occurrence for %s at %s @ %s with role %d",
+		e.occ1.Symbol, e.path, scipRangeToString(*scip.NewRange(e.occ1.Range)), e.occ1.SymbolRoles)
+}
+
+type note struct {
+	message string
+}
+
+func (n note) Error() string {
+	return fmt.Sprintf("note: %s", n.message)
+}
+
+// --- Miscellaneous utility types ---
+
+type errorSet struct {
+	data []error
+}
+
+func (e *errorSet) Add(err error) {
+	e.data = append(e.data, err)
+}
+
+func (e *errorSet) Unique() []error {
+	m := map[string]error{}
+	for _, e := range e.data {
+		m[e.Error()] = e
+	}
+	var out []error
+	for _, e := range m {
+		out = append(out, e)
+	}
+	sort.Sort(mySlice[error]{out, func(e1 error, e2 error) bool {
+		return e1.Error() < e2.Error()
+	}})
+	return out
+}
+
+type mySlice[T any] struct {
+	data []T
+	cmp  func(T, T) bool
+}
+
+func (s mySlice[T]) Len() int {
+	return len(s.data)
+}
+func (s mySlice[T]) Swap(i int, j int) {
+	s.data[i], s.data[j] = s.data[j], s.data[i]
+}
+func (s mySlice[T]) Less(i int, j int) bool {
+	return s.cmp(s.data[i], s.data[j])
+}
+
+type set[T comparable] struct {
+	impl map[T]struct{}
+}
+
+func newSet[T comparable]() set[T] {
+	return set[T]{impl: map[T]struct{}{}}
+}
+
+func (s *set[T]) Add(t T) bool {
+	if _, ok := s.impl[t]; ok {
+		return false
+	}
+	s.impl[t] = struct{}{}
+	return true
+}
+
+func (s *set[T]) Contains(t T) bool {
+	_, ok := s.impl[t]
+	return ok
+}
+
+type pair[T any] struct {
+	first  T
+	second T
+}

--- a/cmd/lint_test.go
+++ b/cmd/lint_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/scip/bindings/go/scip"
+)
+
+type stringMap = map[string][]string
+
+var symbolRegexp = regexp.MustCompile(`([0-9a-zA-Z]*)(.*)`)
+var relationsRegexp = regexp.MustCompile(`~([0-9a-zA-Z]*)#([rdit]*)`)
+
+// parseSymbolInfo allows compactly specifying relationships based on the grammar:
+//
+//	  <kind> ::= 'r' | 'd' | 'i' | 't'
+//	  <name> ::= [0-9a-zA-Z]*
+//	  <symbol> = <name> ('~' <name> '#' ( <kind> )* )*
+//	  ^ symbol name                        ^ relationship
+//		                      ^ related symbol name
+func parseSymbolInfo(symInfoStr string) *scip.SymbolInformation {
+	matches := symbolRegexp.FindStringSubmatch(symInfoStr)
+	if matches == nil {
+		panic(fmt.Sprintf("failed to parse symbol info string %s", symInfoStr))
+	}
+	sym := matches[1]
+	relText := matches[2]
+	var rels []*scip.Relationship
+	if relText != "" {
+		for _, match := range relationsRegexp.FindAllStringSubmatch(relText, -1) {
+			rel := scip.Relationship{Symbol: match[1]}
+			relFields := match[2]
+			if strings.ContainsRune(relFields, 'r') {
+				rel.IsReference = true
+			}
+			if strings.ContainsRune(relFields, 'd') {
+				rel.IsDefinition = true
+			}
+			if strings.ContainsRune(relFields, 'i') {
+				rel.IsImplementation = true
+			}
+			if strings.ContainsRune(relFields, 't') {
+				rel.IsTypeDefinition = true
+			}
+			rels = append(rels, &rel)
+		}
+	}
+	return &scip.SymbolInformation{Symbol: sym, Relationships: rels}
+}
+
+var placeholderRange = []int32{0, 0, 0}
+
+const placeholderRole int32 = 0
+
+func makeIndex(extSyms []string, docSyms stringMap, docOccs stringMap) *scip.Index {
+	scipExtSyms := make([]*scip.SymbolInformation, 0, len(extSyms))
+	for _, s := range extSyms {
+		scipExtSyms = append(scipExtSyms, parseSymbolInfo(s))
+	}
+	if docOccs == nil {
+		docOccs = map[string][]string{}
+	}
+	docs := make([]*scip.Document, 0, len(docSyms))
+	for p, ss := range docSyms {
+		syms := make([]*scip.SymbolInformation, 0, len(ss))
+		for _, s := range ss {
+			syms = append(syms, parseSymbolInfo(s))
+		}
+		var occs []*scip.Occurrence
+		if foundOccs, ok := docOccs[p]; ok {
+			for _, s := range foundOccs {
+				occs = append(occs, &scip.Occurrence{Symbol: s, Range: placeholderRange, SymbolRoles: placeholderRole})
+			}
+			delete(docOccs, p)
+		}
+		docs = append(docs, &scip.Document{RelativePath: p, Symbols: syms, Occurrences: occs})
+	}
+	for p, ss := range docOccs {
+		occs := make([]*scip.Occurrence, 0, len(ss))
+		for _, s := range ss {
+			occs = append(occs, &scip.Occurrence{Symbol: s, Range: placeholderRange, SymbolRoles: placeholderRole})
+		}
+		delete(docOccs, p)
+		docs = append(docs, &scip.Document{RelativePath: p, Symbols: nil, Occurrences: occs})
+	}
+	return &scip.Index{Documents: docs, ExternalSymbols: scipExtSyms}
+}
+
+type testCase struct {
+	name           string
+	index          *scip.Index
+	expectedErrors []error
+}
+
+func TestErrors(t *testing.T) {
+	var testCases []testCase
+
+	testCases = []testCase{
+		{"duplicateSymbolInfo",
+			makeIndex(
+				nil,
+				stringMap{"myfile": {"dupSym", "dupSym"}},
+				nil),
+			[]error{
+				duplicateSymbolInfoWarning{"dupSym", "myfile"},
+			}},
+		{
+			"emptyString",
+			makeIndex([]string{"", "k~#r"}, stringMap{"": nil, "a": {"", "b", "h~#r"}}, stringMap{"c": {""}}),
+			[]error{
+				emptyStringError{"symbol", "external symbols"},
+				emptyStringError{"document", "index"},
+				emptyStringError{"symbol", "symbols for document a"},
+				emptyStringError{"symbol", "occurrence at c @ 0:0-0:0"},
+				emptyStringError{"symbol", "relationships for h"},
+				emptyStringError{"symbol", "relationships for external symbol k"},
+			},
+		},
+		{
+			"duplicateDocument",
+			&scip.Index{Documents: []*scip.Document{{RelativePath: "dup"}, {RelativePath: "dup"}}},
+			[]error{
+				duplicateDocumentWarning{"dup"},
+			},
+		},
+		{
+			"bothLocalAndExternalSymbol",
+			makeIndex([]string{"foo"}, stringMap{"x": {"foo"}}, nil),
+			[]error{
+				bothLocalAndExternalSymbolError{"foo", "x"},
+			},
+		},
+		{
+			"missingRelationshipFlag",
+			makeIndex([]string{"b", "a~b#"}, stringMap{"f": {"x~a#"}}, nil),
+			[]error{
+				missingRelationshipFlagError{"a", "external symbols"},
+				missingRelationshipFlagError{"x", "symbols for file f"},
+			},
+		},
+		{
+			"missingSymbolInRelationship",
+			makeIndex([]string{"a~b#r"}, stringMap{"f": {"x~y#r"}}, nil),
+			[]error{
+				missingSymbolInRelationshipError{
+					"a", "external symbols",
+					"b", "external symbols",
+				},
+				missingSymbolInRelationshipError{
+					"x", "symbols for file f",
+					"y", "external symbols or some other document",
+				},
+			},
+		},
+		{
+			"multipleRelationship",
+			makeIndex([]string{"b", "a~b#r", "a~b#d"}, stringMap{"f": {"x~a#r", "x~a#d"}}, nil),
+			[]error{
+				multipleRelationshipWarning{"a", "b"},
+				multipleRelationshipWarning{"x", "a"},
+			},
+		},
+		{
+			"missingSymbolForOccurrence",
+			makeIndex(nil, nil, stringMap{"f": {"a"}}),
+			[]error{
+				missingSymbolForOccurrenceError{"a", "f", *scip.NewRange(placeholderRange)},
+			},
+		},
+		{
+			"duplicateOccurrence",
+			makeIndex([]string{"a"}, stringMap{"f": {"b"}}, stringMap{"f": {"a", "a", "b", "b"}}),
+			[]error{
+				duplicateOccurrenceWarning{"a", "f", *scip.NewRange(placeholderRange), placeholderRole},
+				duplicateOccurrenceWarning{"b", "f", *scip.NewRange(placeholderRange), placeholderRole},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		errMsgSet := errorMessages(lintMainPure(testCase.index))
+		for _, expectErr := range testCase.expectedErrors {
+			if !errMsgSet.Contains(expectErr.Error()) {
+				t.Errorf("test %s failure: expected\n%s\nbut it wasn't present in error set:\n%s",
+					testCase.name, expectErr.Error(), setToString(errMsgSet, func(t string) string { return t + "\n" }))
+			}
+		}
+	}
+}
+
+func errorMessages(e errorSet) set[string] {
+	out := newSet[string]()
+	for _, e := range e.data {
+		out.Add(e.Error())
+	}
+	return out
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,10 +16,11 @@ func main() {
 
 func commands() []*cli.Command {
 	convert := convertCommand()
+	lint := lintCommand()
+	print := printCommand()
 	snapshot := snapshotCommand()
 	stats := statsCommand()
-	print := printCommand()
-	return []*cli.Command{&convert, &snapshot, &stats, &print}
+	return []*cli.Command{&convert, &lint, &print, &snapshot, &stats}
 }
 
 func scipApp() *cli.App {

--- a/go.sum
+++ b/go.sum
@@ -49,7 +49,6 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
-github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -325,8 +324,6 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
-github.com/urfave/cli/v2 v2.8.1 h1:CGuYNZF9IKZY/rfBe3lJpccSoIY1ytfvmgQT90cNOl4=
-github.com/urfave/cli/v2 v2.8.1/go.mod h1:Z41J9TPoffeoqP0Iza0YbAhGvymRdZAd2uPmZ5JxRdY=
 github.com/urfave/cli/v2 v2.17.1 h1:UzjDEw2dJQUE3iRaiNQ1VrVFbyAtKGH3VdkMoHA58V0=
 github.com/urfave/cli/v2 v2.17.1/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
@@ -536,7 +533,6 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Fixes #90.

### Test plan

Tested manually against an index generated by scip-ruby, and it did flag a bunch of errors.

TODO:
- [x] Add some automated tests for the different error paths.