### PR TITLE
docs: Rework README to mention indexers.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,7 @@ Several indexers currently emit SCIP data:
 [scip-java](https://github.com/sourcegraph/scip-java) (for Java, Kotlin and Scala),
 [scip-typescript](https://github.com/sourcegraph/scip-typescript),
 [scip-python](https://github.com/sourcegraph/scip-python),
-[scip-ruby](https://github.com/sourcegraph/scip-ruby),
+[scip-ruby](https://github.com/sourcegraph/scip-ruby) and
 [rust-analyzer](https://github.com/sourcegraph/rust-analyzer).
 
 For more details about indexers, including LSIF-based indexers,

--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ This repository includes:
 - Rich Go bindings for SCIP: This includes many utility functions
   to help build tooling on top of SCIP.
 - Auto-generated bindings for TypeScript, Rust and Haskell.
-- The [`scip` CLI](#scip-cli-reference) makes SCIP indexes
+- The [`scip` CLI](./docs/CLI.md) makes SCIP indexes
   a breeze to work with.
 
 If you're interested in better understanding the motivation behind SCIP,
@@ -30,6 +30,32 @@ Also, check out the [Debugging section][] in the Development docs.
 
 [debugging section]: ./Development.md#debugging
 
+## Tools using SCIP
+
+Several indexers currently emit SCIP data:
+[scip-java](https://github.com/sourcegraph/scip-java) (for Java, Kotlin and Scala),
+[scip-typescript](https://github.com/sourcegraph/scip-typescript),
+[scip-python](https://github.com/sourcegraph/scip-python),
+[scip-ruby](https://github.com/sourcegraph/scip-ruby),
+[rust-analyzer](https://github.com/sourcegraph/rust-analyzer).
+
+For more details about indexers, including LSIF-based indexers,
+see the [Sourcegraph documentation](https://docs.sourcegraph.com/code_navigation/references/indexers).
+
+Other tools which use SCIP include the [Sourcegraph CLI](https://github.com/sourcegraph/src-cli),
+and the SCIP CLI in this repo.
+
+## Installing the `scip` CLI
+
+You can find binaries for the `scip` CLI tool [here](https://github.com/sourcegraph/scip/releases).
+You can also compile a binary locally using:
+
+```sh
+git clone https://github.com/sourcegraph/scip.git --depth=1
+cd scip
+go build -o scip ./cmd
+```
+
 ## Contributing
 
 We welcome questions, suggestions as well as code and docs contributions.
@@ -38,130 +64,3 @@ For submitting contributions, check out [Development.md](./Development.md)
 to better understand project structure and common workflows.
 
 Contributors should abide by the [Sourcegraph Code of Conduct](https://handbook.sourcegraph.com/company-info-and-process/communication/code_of_conduct/).
-
-## Installing CLI
-
-You can find binaries for `scip`
-[here](https://github.com/sourcegraph/scip/releases). If you'd like to create a
-binary locally you can do so with:
-
-```sh
-git clone https://github.com/sourcegraph/scip.git --depth=1
-cd scip
-go build -o scip ./cmd
-```
-
-## SCIP CLI reference
-
-```
-NAME:
-   scip - SCIP Code Intelligence Protocol CLI
-
-USAGE:
-   scip [global options] command [command options] [arguments...]
-
-VERSION:
-   v0.2.1-git
-
-DESCRIPTION:
-   For more details, see the project README at:
-
-     https://github.com/sourcegraph/scip
-
-COMMANDS:
-   convert   Convert a SCIP index to an LSIF index
-   lint      Flag potential issues with a SCIP index
-   print     Print a SCIP index in a human-readable format for debugging
-   snapshot  Generate snapshot files for golden testing
-   stats     Output useful statistics about a SCIP index
-   help, h   Shows a list of commands or help for one command
-
-GLOBAL OPTIONS:
-   --help, -h     show help (default: false)
-   --version, -v  print the version (default: false)
-```
-
-### `scip convert`
-
-```
-NAME:
-   scip convert - Convert a SCIP index to an LSIF index
-
-USAGE:
-   scip convert [command options] [arguments...]
-
-OPTIONS:
-   --from value  Path to SCIP index file (default: index.scip)
-   --to value    Output path for LSIF index (default: dump.lsif)
-```
-
-### `scip lint`
-
-```
-NAME:
-   scip lint - Flag potential issues with a SCIP index
-
-USAGE:
-   scip lint [command options] [arguments...]
-
-DESCRIPTION:
-   Example usage:
-
-     scip lint /path/to/index.scip
-
-   You may want to filter the output using `grep -v <pattern>`
-   to narrow down on certain classes of errors.
-
-OPTIONS:
-   --help, -h  show help (default: false)
-```
-
-### `scip print`
-
-```
-NAME:
-   scip print - Print a SCIP index in a human-readable format for debugging
-
-USAGE:
-   scip print [command options] [arguments...]
-
-DESCRIPTION:
-   WARNING: The output may change over time.
-   Do not rely on the output of this command in scripts
-
-OPTIONS:
-   --help, -h  show help (default: false)
-```
-
-### `scip snapshot`
-
-```
-NAME:
-   scip snapshot - Generate snapshot files for golden testing
-
-USAGE:
-   scip snapshot [command options] [arguments...]
-
-DESCRIPTION:
-   The snapshot subcommand generates snapshot files which
-   can be use for inspecting the output of an index in a
-   visual way. Occurrences are marked with caret signs (^)
-   and symbol information.
-
-OPTIONS:
-   --from value  Path to SCIP index file (default: index.scip)
-   --to value    Path to output directory for snapshot files (default: scip-snapshot)
-```
-
-### `scip stats`
-
-```
-NAME:
-   scip stats - Output useful statistics about a SCIP index
-
-USAGE:
-   scip stats [command options] [arguments...]
-
-OPTIONS:
-   --from value  Path to SCIP index file (default: index.scip)
-```

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/sourcegraph/scip/cmd/tests/reprolang/bindings/go/repro"
 )
 
-func TestReadmeInSync(t *testing.T) {
+func TestCLIReferenceInSync(t *testing.T) {
 	app := scipApp()
-	readmeBytes, err := os.ReadFile(filepath.Join("..", "Readme.md"))
+	readmeBytes, err := os.ReadFile(filepath.Join("..", "docs", "CLI.md"))
 	require.Nil(t, err)
 	readme := string(readmeBytes)
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,114 @@
+# SCIP CLI Reference
+
+```
+NAME:
+   scip - SCIP Code Intelligence Protocol CLI
+
+USAGE:
+   scip [global options] command [command options] [arguments...]
+
+VERSION:
+   v0.2.1-git
+
+DESCRIPTION:
+   For more details, see the project README at:
+
+     https://github.com/sourcegraph/scip
+
+COMMANDS:
+   convert   Convert a SCIP index to an LSIF index
+   lint      Flag potential issues with a SCIP index
+   print     Print a SCIP index in a human-readable format for debugging
+   snapshot  Generate snapshot files for golden testing
+   stats     Output useful statistics about a SCIP index
+   help, h   Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --help, -h     show help (default: false)
+   --version, -v  print the version (default: false)
+```
+
+## `scip convert`
+
+```
+NAME:
+   scip convert - Convert a SCIP index to an LSIF index
+
+USAGE:
+   scip convert [command options] [arguments...]
+
+OPTIONS:
+   --from value  Path to SCIP index file (default: index.scip)
+   --to value    Output path for LSIF index (default: dump.lsif)
+```
+
+## `scip lint`
+
+```
+NAME:
+   scip lint - Flag potential issues with a SCIP index
+
+USAGE:
+   scip lint [command options] [arguments...]
+
+DESCRIPTION:
+   Example usage:
+
+     scip lint /path/to/index.scip
+
+   You may want to filter the output using `grep -v <pattern>`
+   to narrow down on certain classes of errors.
+
+OPTIONS:
+   --help, -h  show help (default: false)
+```
+
+## `scip print`
+
+```
+NAME:
+   scip print - Print a SCIP index in a human-readable format for debugging
+
+USAGE:
+   scip print [command options] [arguments...]
+
+DESCRIPTION:
+   WARNING: The output may change over time.
+   Do not rely on the output of this command in scripts
+
+OPTIONS:
+   --help, -h  show help (default: false)
+```
+
+## `scip snapshot`
+
+```
+NAME:
+   scip snapshot - Generate snapshot files for golden testing
+
+USAGE:
+   scip snapshot [command options] [arguments...]
+
+DESCRIPTION:
+   The snapshot subcommand generates snapshot files which
+   can be use for inspecting the output of an index in a
+   visual way. Occurrences are marked with caret signs (^)
+   and symbol information.
+
+OPTIONS:
+   --from value  Path to SCIP index file (default: index.scip)
+   --to value    Path to output directory for snapshot files (default: scip-snapshot)
+```
+
+## `scip stats`
+
+```
+NAME:
+   scip stats - Output useful statistics about a SCIP index
+
+USAGE:
+   scip stats [command options] [arguments...]
+
+OPTIONS:
+   --from value  Path to SCIP index file (default: index.scip)
+```


### PR DESCRIPTION
I've moved out the CLI reference into a separate doc to reduce clutter.

The lack of mention of indexers was flagged on HN: https://news.ycombinator.com/item?id=33082636

### Test plan

n/a
