### PR TITLE
Bump `urfave/cli` and remove redundant code

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -44,8 +43,6 @@ func TestCLIReferenceInSync(t *testing.T) {
 		helpBytes = helpBytes[:n-1] // ignore NULL at end
 		require.Nil(t, err)
 		help := strings.TrimSpace(string(helpBytes))
-		re := regexp.MustCompile(`(?m)\s+$`) // strip trailing whitespace
-		help = re.ReplaceAllString(help, "\n")
 		require.Truef(t, strings.Contains(readme, help),
 			"Readme.md missing help text %s for %s.\nRun `%s` and paste the output in the Readme.",
 			help, commandName, strings.Join(append([]string{"scip"}, args...), " "))

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/smacker/go-tree-sitter v0.0.0-20220209044044-0d3022e933c3
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20220511160847-5a43d3ea24eb
 	github.com/stretchr/testify v1.7.1
-	github.com/urfave/cli/v2 v2.17.1
+	github.com/urfave/cli/v2 v2.19.1
 	golang.org/x/tools v0.1.10
 	google.golang.org/protobuf v1.28.0
 )

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,8 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli/v2 v2.17.1 h1:UzjDEw2dJQUE3iRaiNQ1VrVFbyAtKGH3VdkMoHA58V0=
 github.com/urfave/cli/v2 v2.17.1/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
+github.com/urfave/cli/v2 v2.19.1 h1:5Lt6gp6VugLvDmsyl80uqZlmCn/gyI9af8JvC2voqCI=
+github.com/urfave/cli/v2 v2.19.1/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBnvPM1Su9w=


### PR DESCRIPTION
New version of `urfave/cli` is released with fixes for trailing whitespace.

https://github.com/urfave/cli/discussions/1518

### Test plan

```
cd cmd
go test
``` 