### PR TITLE
Snapshot: don't fail on unparseable symbols.

### DIFF
--- a/bindings/go/scip/symbol_formatter.go
+++ b/bindings/go/scip/symbol_formatter.go
@@ -8,6 +8,7 @@ import (
 // Excluding parts of the symbol can be helpful for testing purposes. For example, snapshot tests may hardcode
 // the package version number so it's easier to read the snapshot tests if the version is excluded.
 type SymbolFormatter struct {
+	OnError               func(err error) error
 	IncludeScheme         func(scheme string) bool
 	IncludePackageManager func(manager string) bool
 	IncludePackageName    func(name string) bool
@@ -17,6 +18,17 @@ type SymbolFormatter struct {
 
 // VerboseSymbolFormatter formats all parts of the symbol.
 var VerboseSymbolFormatter = SymbolFormatter{
+	OnError:               func(err error) error { return err },
+	IncludeScheme:         func(_ string) bool { return true },
+	IncludePackageManager: func(_ string) bool { return true },
+	IncludePackageName:    func(_ string) bool { return true },
+	IncludePackageVersion: func(_ string) bool { return true },
+	IncludeDescriptor:     func(_ string) bool { return true },
+}
+
+// Same as VerboseSymbolFormatter but silently ignores errors.
+var LenientVerboseSymbolFormatter = SymbolFormatter{
+	OnError:               func(_ error) error { return nil },
 	IncludeScheme:         func(_ string) bool { return true },
 	IncludePackageManager: func(_ string) bool { return true },
 	IncludePackageName:    func(_ string) bool { return true },
@@ -26,6 +38,7 @@ var VerboseSymbolFormatter = SymbolFormatter{
 
 // DescriptorOnlyFormatter formats only the descriptor part of the symbol.
 var DescriptorOnlyFormatter = SymbolFormatter{
+	OnError:               func(err error) error { return err },
 	IncludeScheme:         func(scheme string) bool { return scheme == "local" },
 	IncludePackageManager: func(_ string) bool { return false },
 	IncludePackageName:    func(_ string) bool { return false },

--- a/bindings/go/scip/testutil/format.go
+++ b/bindings/go/scip/testutil/format.go
@@ -26,6 +26,7 @@ func FormatSnapshots(
 	}
 	for _, document := range index.Documents {
 		snapshot, err := FormatSnapshot(document, index, commentSyntax, symbolFormatter)
+		err = symbolFormatter.OnError(err)
 		if err != nil {
 			return nil, err
 		}
@@ -68,7 +69,7 @@ func FormatSnapshot(
 		formatted, err := formatter.Format(symbol)
 		if err != nil {
 			formattingError = errors.CombineErrors(formattingError, errors.Wrapf(err, symbol))
-			return err.Error()
+			return symbol
 		}
 		return formatted
 	}

--- a/bindings/go/scip/testutil/format.go
+++ b/bindings/go/scip/testutil/format.go
@@ -24,11 +24,16 @@ func FormatSnapshots(
 	if err != nil {
 		return nil, err
 	}
+
+	var documentErrors error
 	for _, document := range index.Documents {
 		snapshot, err := FormatSnapshot(document, index, commentSyntax, symbolFormatter)
 		err = symbolFormatter.OnError(err)
 		if err != nil {
-			return nil, err
+			documentErrors = errors.CombineErrors(
+				documentErrors,
+				errors.Wrap(err, document.RelativePath),
+			)
 		}
 		sourceFile := scip.NewSourceFile(
 			filepath.Join(projectRoot.Path, document.RelativePath),
@@ -36,6 +41,9 @@ func FormatSnapshots(
 			snapshot,
 		)
 		result = append(result, sourceFile)
+	}
+	if documentErrors != nil {
+		return nil, documentErrors
 	}
 	return result, nil
 }

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -14,6 +14,7 @@ import (
 type snapshotFlags struct {
 	from   string
 	output string
+	strict bool
 }
 
 func snapshotCommand() cli.Command {
@@ -31,7 +32,13 @@ and symbol information.`,
 				Name:        "to",
 				Usage:       "Path to output directory for snapshot files",
 				Destination: &snapshotFlags.output,
-				Value: "scip-snapshot",
+				Value:       "scip-snapshot",
+			},
+			&cli.BoolFlag{
+				Name:        "strict",
+				Usage:       "If true, fail fast on errors",
+				Destination: &snapshotFlags.strict,
+				Value:       false,
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -52,7 +59,11 @@ func snapshotMain(flags snapshotFlags) error {
 	if err != nil {
 		return err
 	}
-	snapshots, err := testutil.FormatSnapshots(index, "//", scip.VerboseSymbolFormatter)
+	symbolFormatter := scip.LenientVerboseSymbolFormatter
+	if flags.strict {
+		symbolFormatter = scip.VerboseSymbolFormatter
+	}
+	snapshots, err := testutil.FormatSnapshots(index, "//", symbolFormatter)
 	if err != nil {
 		return err
 	}

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/scip/bindings/go/scip"
 	"github.com/sourcegraph/scip/bindings/go/scip/testutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type snapshotFlags struct {
@@ -38,7 +39,7 @@ and symbol information.`,
 				Name:        "strict",
 				Usage:       "If true, fail fast on errors",
 				Destination: &snapshotFlags.strict,
-				Value:       false,
+				Value:       true,
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -62,6 +63,9 @@ func snapshotMain(flags snapshotFlags) error {
 	symbolFormatter := scip.LenientVerboseSymbolFormatter
 	if flags.strict {
 		symbolFormatter = scip.VerboseSymbolFormatter
+		symbolFormatter.OnError = func(err error) error {
+			return errors.Wrap(err, "use --strict=false to ignore this error")
+		}
 	}
 	snapshots, err := testutil.FormatSnapshots(index, "//", symbolFormatter)
 	if err != nil {


### PR DESCRIPTION
Previously, the `scip snapshot` command failed if there was a symbol that wasn't parseable. This was unhelpful when trying to debug why navigation was not working as expected (which is the main situation where I use `scip snapshot`). Unparseable symbols are not invalid, they just don't work with cross-repo navigation. To fail fast like before, there's a new `scip snapshot --strict` flag that fails if there's a parser error.

### Test plan

Manually tested locally.
