### PR TITLE
Remove debugging output from symbol.rs that cannot otherwise be disabled.

### DIFF
--- a/bindings/rust/src/symbol.rs
+++ b/bindings/rust/src/symbol.rs
@@ -281,7 +281,7 @@ impl SymbolParser {
     fn accept_descriptors(&mut self) -> Result<Vec<Descriptor>, SymbolError> {
         let mut v = Vec::new();
         while self.index < self.sym.len() {
-            v.push(dbg!(self.accept_one_descriptor()?))
+            v.push(self.accept_one_descriptor()?)
         }
 
         Ok(v)

--- a/bindings/rust/src/symbol.rs
+++ b/bindings/rust/src/symbol.rs
@@ -263,7 +263,6 @@ impl SymbolParser {
     }
 
     fn accept_character(&mut self, c: char, what: &str) -> Result<char, SymbolError> {
-        println!("Checking: {} for {}", c, what);
         // if self.peek_next().ok_or(SymbolError::InvalidIndex)? == c {
         if self.current()? == c {
             self.index += 1;


### PR DESCRIPTION
As documented at https://doc.rust-lang.org/std/macro.dbg.html the dbg! macro unconditionally prints its argument to stderr, even in release builds.  (It is not possible to quiet it through use of RUST_LOG.)

Presumably this was accidentally left in.