### PR TITLE
[rust bindings] Allow zero-length method disambiguation.

### DIFF
--- a/bindings/rust/Cargo.lock
+++ b/bindings/rust/Cargo.lock
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee4a7d8b91800c8f167a6268d1a1026607368e1adc84e98fe044aeb905302f7"
+checksum = "b55bad9126f378a853655831eb7363b7b01b81d19f8cb1218861086ca4a1a61e"
 dependencies = [
  "once_cell",
  "protobuf-support",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca157fe12fc7ee2e315f2f735e27df41b3d97cdd70ea112824dac1ffb08ee1c"
+checksum = "a5d4d7b8601c814cfb36bcebb79f0e61e45e1e93640cf778837833bbed05c372"
 dependencies = [
  "thiserror",
 ]
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "scip"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pretty_assertions",
  "protobuf",

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -24,3 +24,5 @@ pretty_assertions = "1.2.1"
 [lib]
 name = "scip"
 path = "src/mod.rs"
+# disable doctests because generated/scip.rs has a perceived doctest.
+doctest = false

--- a/bindings/rust/src/symbol.rs
+++ b/bindings/rust/src/symbol.rs
@@ -432,9 +432,8 @@ mod test {
     }
 
     #[test]
-    fn parses_rust_symbol() {
-        let input_symbol =
-            "rust-analyzer cargo test_rust_dependency 0.1.0 MyType#new().";
+    fn parses_rust_method_no_disambiguator() {
+        let input_symbol = "rust-analyzer cargo test_rust_dependency 0.1.0 MyType#new().";
 
         assert_eq!(
             parse_symbol(input_symbol).expect("rust symbol"),
@@ -447,6 +446,33 @@ mod test {
                         "new".to_string(),
                         descriptor::Suffix::Method,
                         "".to_string(),
+                    ),
+                ],
+                special_fields: SpecialFields::default(),
+            }
+        );
+
+        assert_eq!(
+            input_symbol,
+            format_symbol(parse_symbol(input_symbol).expect("rust symbol"))
+        )
+    }
+
+    #[test]
+    fn parses_rust_method_with_disambiguator() {
+        let input_symbol = "rust-analyzer cargo test_rust_dependency 0.1.0 MyType#new(test).";
+
+        assert_eq!(
+            parse_symbol(input_symbol).expect("rust symbol"),
+            Symbol {
+                scheme: "rust-analyzer".to_string(),
+                package: Package::new_with_values("cargo", "test_rust_dependency", "0.1.0"),
+                descriptors: vec![
+                    new_descriptor("MyType".to_string(), descriptor::Suffix::Type),
+                    new_descriptor_with_disambiguator(
+                        "new".to_string(),
+                        descriptor::Suffix::Method,
+                        "test".to_string(),
                     ),
                 ],
                 special_fields: SpecialFields::default(),


### PR DESCRIPTION
parse_symbol was failing on a bunch of rust symbols that look like "rust-analyzer cargo test_rust_dependency 0.1.0 MyType#new()." with `Err(InvalidIdentifier("method disambiguator"))`.

The problem is that the method descriptor was attempting to use peek to look for the character after the opening "(" to see if it was a ")", but the index had already been incremented, so peek would see the "." closing character instead of the ")".

I also have a change in this patch to disable automatic doctests because `cargo test` is failing for me locally without this because it seems to view the inlined protobuf schema as a doctest and reasonably has trouble parsing the schema as valid rust code.  I am not able to delve into the general machinery around the "generated" directory at this time, but it seems nice for the tests to pass, so this seems like a reasonable band-aid.