### PR TITLE
chore: move to non-deprecated symbol

### DIFF
--- a/bindings/go/scip/symbol.go
+++ b/bindings/go/scip/symbol.go
@@ -156,7 +156,7 @@ func (s *symbolParser) parseDescriptor() (*Descriptor, error) {
 			}
 			return &Descriptor{Name: name, Disambiguator: disambiguator, Suffix: Descriptor_Method}, s.acceptCharacter('.', "closing method")
 		case '/':
-			return &Descriptor{Name: name, Suffix: Descriptor_Package}, nil
+			return &Descriptor{Name: name, Suffix: Descriptor_Namespace}, nil
 		case '.':
 			return &Descriptor{Name: name, Suffix: Descriptor_Term}, nil
 		case '#':

--- a/bindings/go/scip/symbol_formatter.go
+++ b/bindings/go/scip/symbol_formatter.go
@@ -71,7 +71,7 @@ func (f *SymbolFormatter) FormatSymbol(symbol *Symbol) string {
 	descriptor := strings.Builder{}
 	for _, desc := range symbol.Descriptors {
 		switch desc.Suffix {
-		case Descriptor_Package:
+		case Descriptor_Namespace:
 			descriptor.WriteString(desc.Name)
 			descriptor.WriteRune('/')
 		case Descriptor_Type:

--- a/bindings/go/scip/symbol_test.go
+++ b/bindings/go/scip/symbol_test.go
@@ -49,8 +49,8 @@ func TestParseSymbol(t *testing.T) {
 				Scheme:  "lsif-java",
 				Package: &Package{Manager: "maven", Name: "package", Version: "1.0.0"},
 				Descriptors: []*Descriptor{
-					{Name: "java", Suffix: Descriptor_Package},
-					{Name: "io", Suffix: Descriptor_Package},
+					{Name: "java", Suffix: Descriptor_Namespace},
+					{Name: "io", Suffix: Descriptor_Namespace},
 					{Name: "File", Suffix: Descriptor_Type},
 					{Name: "Entry", Suffix: Descriptor_Term},
 					{Name: "method", Disambiguator: "+1", Suffix: Descriptor_Method},
@@ -65,7 +65,7 @@ func TestParseSymbol(t *testing.T) {
 				Scheme:  "rust-analyzer",
 				Package: &Package{Manager: "cargo", Name: "std", Version: "1.0.0"},
 				Descriptors: []*Descriptor{
-					{Name: "macros", Suffix: Descriptor_Package},
+					{Name: "macros", Suffix: Descriptor_Namespace},
 					{Name: "println", Suffix: Descriptor_Macro},
 				},
 			},


### PR DESCRIPTION
Closes: #73

### Test plan
- [ ] Still green CI. No changes outside of using new symbol.