### PR TITLE
ci: add running rust tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,13 @@ jobs:
         with:
           rust: true
       - run: cargo check
-        working-directory: bindings/rust
-      - run: cargo check
         working-directory: cmd/tests/reprolang
+  rust-bindings-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/asdf
+        with:
+          rust: true
+      - run: cargo test
+        working-directory: bindings/rust


### PR DESCRIPTION
Enable running rust tests in CI

### Test plan
- [ ] Green tests (now actually running cargo test)