### PR TITLE
Add --project-root option to override the root inside scip files

### DIFF
--- a/bindings/go/scip/testutil/format.go
+++ b/bindings/go/scip/testutil/format.go
@@ -19,7 +19,7 @@ func FormatSnapshots(
 	index *scip.Index,
 	commentSyntax string,
 	symbolFormatter scip.SymbolFormatter,
-	root string,
+	customProjectRoot string,
 ) ([]*scip.SourceFile, error) {
 	var result []*scip.SourceFile
 	projectRootUrl, err := url.Parse(index.Metadata.ProjectRoot)
@@ -28,8 +28,8 @@ func FormatSnapshots(
 	}
 
 	localSourcesRoot := projectRootUrl.Path
-	if root != "" {
-		localSourcesRoot = root
+	if customProjectRoot != "" {
+		localSourcesRoot = customProjectRoot
 	} else if _, err := os.Stat(localSourcesRoot); errors.Is(err, os.ErrNotExist) {
 		cwd, _ := os.Getwd()
 		log.Printf("Project root [%s] doesn't exist, using current working directory [%s] instead. "+

--- a/bindings/go/scip/testutil/format.go
+++ b/bindings/go/scip/testutil/format.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -18,16 +19,28 @@ func FormatSnapshots(
 	index *scip.Index,
 	commentSyntax string,
 	symbolFormatter scip.SymbolFormatter,
+	root string,
 ) ([]*scip.SourceFile, error) {
 	var result []*scip.SourceFile
-	projectRoot, err := url.Parse(index.Metadata.ProjectRoot)
+	projectRootUrl, err := url.Parse(index.Metadata.ProjectRoot)
 	if err != nil {
 		return nil, err
 	}
 
+	localSourcesRoot := projectRootUrl.Path
+	if root != "" {
+		localSourcesRoot = root
+	} else if _, err := os.Stat(localSourcesRoot); errors.Is(err, os.ErrNotExist) {
+		cwd, _ := os.Getwd()
+		log.Printf("Project root [%s] doesn't exist, using current working directory [%s] instead. "+
+			"To override this behaviour, use --root=<folder> option directly", projectRootUrl.Path, cwd)
+		localSourcesRoot = cwd
+	}
+
 	var documentErrors error
 	for _, document := range index.Documents {
-		snapshot, err := FormatSnapshot(document, index, commentSyntax, symbolFormatter)
+		sourceFilePath := filepath.Join(localSourcesRoot, document.RelativePath)
+		snapshot, err := FormatSnapshot(document, index, commentSyntax, symbolFormatter, sourceFilePath)
 		err = symbolFormatter.OnError(err)
 		if err != nil {
 			documentErrors = errors.CombineErrors(
@@ -35,8 +48,7 @@ func FormatSnapshots(
 				errors.Wrap(err, document.RelativePath),
 			)
 		}
-		sourceFile := scip.NewSourceFile(
-			filepath.Join(projectRoot.Path, document.RelativePath),
+		sourceFile := scip.NewSourceFile(sourceFilePath,
 			document.RelativePath,
 			snapshot,
 		)
@@ -55,16 +67,10 @@ func FormatSnapshot(
 	index *scip.Index,
 	commentSyntax string,
 	formatter scip.SymbolFormatter,
+	sourceFilePath string,
 ) (string, error) {
 	b := strings.Builder{}
-	uri, err := url.Parse(filepath.Join(index.Metadata.ProjectRoot, document.RelativePath))
-	if err != nil {
-		return "", err
-	}
-	if uri.Scheme != "file" {
-		return "", errors.New("expected url scheme 'file', obtained " + uri.Scheme)
-	}
-	data, err := os.ReadFile(uri.Path)
+	data, err := os.ReadFile(sourceFilePath)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -91,7 +91,7 @@ func TestSCIPSnapshots(t *testing.T) {
 		require.Nil(t, err)
 		symbolFormatter := scip.DescriptorOnlyFormatter
 		symbolFormatter.IncludePackageName = func(name string) bool { return name != testName }
-		snapshots, err := testutil.FormatSnapshots(index, "#", symbolFormatter)
+		snapshots, err := testutil.FormatSnapshots(index, "#", symbolFormatter, "")
 		require.Nil(t, err)
 		if debugSnapshotAbspaths != nil && *debugSnapshotAbspaths {
 			inputDirAbsPath, err := filepath.Abs(inputDirectory)

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -15,6 +15,7 @@ import (
 type snapshotFlags struct {
 	from          string
 	output        string
+	projectRoot   string
 	strict        bool
 	commentSyntax string
 }
@@ -35,6 +36,11 @@ and symbol information.`,
 				Usage:       "Path to output directory for snapshot files",
 				Destination: &snapshotFlags.output,
 				Value:       "scip-snapshot",
+			},
+			&cli.StringFlag{
+				Name:        "project-root",
+				Usage:       "Override projet root in SCIP file",
+				Destination: &snapshotFlags.projectRoot,
 			},
 			&cli.BoolFlag{
 				Name:        "strict",
@@ -74,7 +80,7 @@ func snapshotMain(flags snapshotFlags) error {
 			return errors.Wrap(err, "use --strict=false to ignore this error")
 		}
 	}
-	snapshots, err := testutil.FormatSnapshots(index, flags.commentSyntax, symbolFormatter)
+	snapshots, err := testutil.FormatSnapshots(index, flags.commentSyntax, symbolFormatter, flags.projectRoot)
 	if err != nil {
 		return err
 	}

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -13,11 +13,11 @@ import (
 )
 
 type snapshotFlags struct {
-	from          string
-	output        string
-	projectRoot   string
-	strict        bool
-	commentSyntax string
+	from              string
+	output            string
+	customProjectRoot string
+	strict            bool
+	commentSyntax     string
 }
 
 func snapshotCommand() cli.Command {
@@ -38,9 +38,10 @@ and symbol information.`,
 				Value:       "scip-snapshot",
 			},
 			&cli.StringFlag{
-				Name:        "project-root",
-				Usage:       "Override projet root in SCIP file",
-				Destination: &snapshotFlags.projectRoot,
+				Name: "project-root",
+				Usage: "Override project root in the SCIP file. " +
+					"For example, this can be helpful when the SCIP index was created inside a Docker image or created on another computer",
+				Destination: &snapshotFlags.customProjectRoot,
 			},
 			&cli.BoolFlag{
 				Name:        "strict",
@@ -80,7 +81,7 @@ func snapshotMain(flags snapshotFlags) error {
 			return errors.Wrap(err, "use --strict=false to ignore this error")
 		}
 	}
-	snapshots, err := testutil.FormatSnapshots(index, flags.commentSyntax, symbolFormatter, flags.projectRoot)
+	snapshots, err := testutil.FormatSnapshots(index, flags.commentSyntax, symbolFormatter, flags.customProjectRoot)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This option can be useful if the scip file is produced inside a docker container, and the project root in the file points to a non-existent location.

### Test plan

Manual testing
