### PR TITLE
[rust bindings] parse macro symbols

### DIFF
--- a/bindings/rust/src/symbol.rs
+++ b/bindings/rust/src/symbol.rs
@@ -342,6 +342,7 @@ impl SymbolParser {
                     '.' => Ok(new_descriptor(name, descriptor::Suffix::Term)),
                     '#' => Ok(new_descriptor(name, descriptor::Suffix::Type)),
                     ':' => Ok(new_descriptor(name, descriptor::Suffix::Meta)),
+                    '!' => Ok(new_descriptor(name, descriptor::Suffix::Macro)),
                     _ => Err(SymbolError::MissingDescriptor),
                 }
             }

--- a/bindings/rust/src/symbol.rs
+++ b/bindings/rust/src/symbol.rs
@@ -525,4 +525,27 @@ mod test {
             })
         );
     }
+
+    #[test]
+    fn parses_rust_method_with_macro() {
+        let input_symbol = "rust-analyzer cargo test_rust_dependency 0.1.0 println!";
+
+        assert_eq!(
+            parse_symbol(input_symbol).expect("rust symbol"),
+            Symbol {
+                scheme: "rust-analyzer".to_string(),
+                package: Package::new_with_values("cargo", "test_rust_dependency", "0.1.0"),
+                descriptors: vec![new_descriptor(
+                    "println".to_string(),
+                    descriptor::Suffix::Macro
+                ),],
+                special_fields: SpecialFields::default(),
+            }
+        );
+
+        assert_eq!(
+            input_symbol,
+            format_symbol(parse_symbol(input_symbol).expect("rust symbol"))
+        )
+    }
 }


### PR DESCRIPTION
Macros end in an exclamation point. Currently parsing one results in a MissingDescriptor error, for example:

### Test plan
```rust
dbg!(scip::symbol::parse_symbol("rust-analyzer cargo std https://github.com/rust-lang/rust/library/std macros/print!"));
```