### PR TITLE
Automatically generate Haskell bindings

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -25,8 +25,9 @@ jobs:
           sudo apt install -y unzip curl
       - name: Install protoc
         run: |
-          PROTOC_ZIP=protoc-3.14.0-linux-x86_64.zip
-          curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/"$PROTOC_ZIP"
+          PROTOC_VERSION=23.2
+          PROTOC_ZIP="protoc-$PROTOC_VERSION-linux-x86_64.zip"
+          curl -OL "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP"
           unzip -o "$PROTOC_ZIP" -d "$HOME/.protoc" bin/protoc
           unzip -o "$PROTOC_ZIP" -d "$HOME/.protoc" 'include/*'
           echo "$HOME/.protoc/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -19,24 +19,6 @@ jobs:
         with:
           ghc-version: '8.10'
           cabal-version: 'latest'
-      - name: Install additional tools
-        run: |
-          sudo apt-get update
-          sudo apt install -y unzip curl
-      - name: Install protoc
-        run: |
-          PROTOC_VERSION=23.2
-          PROTOC_ZIP="protoc-$PROTOC_VERSION-linux-x86_64.zip"
-          curl -OL "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP"
-          unzip -o "$PROTOC_ZIP" -d "$HOME/.protoc" bin/protoc
-          unzip -o "$PROTOC_ZIP" -d "$HOME/.protoc" 'include/*'
-          echo "$HOME/.protoc/bin" >> "$GITHUB_PATH"
-      - name: Build proto-lens-protoc wrapper
-        run: cabal install proto-lens-protoc --ghc-options='-j2 +RTS -A32m'
-        working-directory: bindings/haskell
-      - name: Generate Haskell
-        run: protoc --plugin=protoc-gen-haskell="$HOME/.cabal/bin/proto-lens-protoc" --haskell_out=src --proto_path=../.. scip.proto
-        working-directory: bindings/haskell
       - name: Build source
         run: cabal build --ghc-options='-j2 +RTS -A32m'
         working-directory: bindings/haskell

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -19,5 +19,6 @@ jobs:
           js: true
           rust: true
           golang: true
+      - run: cabal update
       - run: ./dev/proto-generate.sh
       - run: git diff --exit-code

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -14,11 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Haskell
+        uses: haskell/actions/setup@v2
+        with:
+          ghc-version: '8.10'
+          cabal-version: 'latest'
       - uses: ./.github/actions/asdf
         with:
           js: true
           rust: true
           golang: true
-      - run: cabal update
       - run: ./dev/proto-generate.sh
       - run: git diff --exit-code

--- a/bindings/haskell/src/Proto/Scip.hs
+++ b/bindings/haskell/src/Proto/Scip.hs
@@ -1,4 +1,4 @@
-{- This file was auto-generated from scip.proto by the proto-lens-protoc program. -}
+{- This file was auto-generated from scip.proto by the protoc-gen-haskell program. -}
 {-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies, UndecidableInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, PatternSynonyms, MagicHash, NoImplicitPrelude, DataKinds, BangPatterns, TypeApplications, OverloadedStrings, DerivingStrategies#-}
 {-# OPTIONS_GHC -Wno-unused-imports#-}
 {-# OPTIONS_GHC -Wno-duplicate-exports#-}
@@ -836,12 +836,14 @@ instance Control.DeepSeq.NFData DiagnosticTag where
          * 'Proto.Scip_Fields.occurrences' @:: Lens' Document [Occurrence]@
          * 'Proto.Scip_Fields.vec'occurrences' @:: Lens' Document (Data.Vector.Vector Occurrence)@
          * 'Proto.Scip_Fields.symbols' @:: Lens' Document [SymbolInformation]@
-         * 'Proto.Scip_Fields.vec'symbols' @:: Lens' Document (Data.Vector.Vector SymbolInformation)@ -}
+         * 'Proto.Scip_Fields.vec'symbols' @:: Lens' Document (Data.Vector.Vector SymbolInformation)@
+         * 'Proto.Scip_Fields.text' @:: Lens' Document Data.Text.Text@ -}
 data Document
   = Document'_constructor {_Document'language :: !Data.Text.Text,
                            _Document'relativePath :: !Data.Text.Text,
                            _Document'occurrences :: !(Data.Vector.Vector Occurrence),
                            _Document'symbols :: !(Data.Vector.Vector SymbolInformation),
+                           _Document'text :: !Data.Text.Text,
                            _Document'_unknownFields :: !Data.ProtoLens.FieldSet}
   deriving stock (Prelude.Eq, Prelude.Ord)
 instance Prelude.Show Document where
@@ -893,6 +895,12 @@ instance Data.ProtoLens.Field.HasField Document "vec'symbols" (Data.Vector.Vecto
         (Lens.Family2.Unchecked.lens
            _Document'symbols (\ x__ y__ -> x__ {_Document'symbols = y__}))
         Prelude.id
+instance Data.ProtoLens.Field.HasField Document "text" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _Document'text (\ x__ y__ -> x__ {_Document'text = y__}))
+        Prelude.id
 instance Data.ProtoLens.Message Document where
   messageName _ = Data.Text.pack "scip.Document"
   packedMessageDescriptor _
@@ -901,7 +909,8 @@ instance Data.ProtoLens.Message Document where
       \\blanguage\CAN\EOT \SOH(\tR\blanguage\DC2#\n\
       \\rrelative_path\CAN\SOH \SOH(\tR\frelativePath\DC22\n\
       \\voccurrences\CAN\STX \ETX(\v2\DLE.scip.OccurrenceR\voccurrences\DC21\n\
-      \\asymbols\CAN\ETX \ETX(\v2\ETB.scip.SymbolInformationR\asymbols"
+      \\asymbols\CAN\ETX \ETX(\v2\ETB.scip.SymbolInformationR\asymbols\DC2\DC2\n\
+      \\EOTtext\CAN\ENQ \SOH(\tR\EOTtext"
   packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
@@ -940,12 +949,21 @@ instance Data.ProtoLens.Message Document where
               (Data.ProtoLens.RepeatedField
                  Data.ProtoLens.Unpacked (Data.ProtoLens.Field.field @"symbols")) ::
               Data.ProtoLens.FieldDescriptor Document
+        text__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "text"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional (Data.ProtoLens.Field.field @"text")) ::
+              Data.ProtoLens.FieldDescriptor Document
       in
         Data.Map.fromList
           [(Data.ProtoLens.Tag 4, language__field_descriptor),
            (Data.ProtoLens.Tag 1, relativePath__field_descriptor),
            (Data.ProtoLens.Tag 2, occurrences__field_descriptor),
-           (Data.ProtoLens.Tag 3, symbols__field_descriptor)]
+           (Data.ProtoLens.Tag 3, symbols__field_descriptor),
+           (Data.ProtoLens.Tag 5, text__field_descriptor)]
   unknownFields
     = Lens.Family2.Unchecked.lens
         _Document'_unknownFields
@@ -956,6 +974,7 @@ instance Data.ProtoLens.Message Document where
          _Document'relativePath = Data.ProtoLens.fieldDefault,
          _Document'occurrences = Data.Vector.Generic.empty,
          _Document'symbols = Data.Vector.Generic.empty,
+         _Document'text = Data.ProtoLens.fieldDefault,
          _Document'_unknownFields = []}
   parseMessage
     = let
@@ -1042,6 +1061,20 @@ instance Data.ProtoLens.Message Document where
                                 v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
                                        (Data.ProtoLens.Encoding.Growing.append mutable'symbols y)
                                 loop x mutable'occurrences v
+                        42
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                       Data.ProtoLens.Encoding.Bytes.getBytes
+                                                         (Prelude.fromIntegral len)
+                                           Data.ProtoLens.Encoding.Bytes.runEither
+                                             (case Data.Text.Encoding.decodeUtf8' value of
+                                                (Prelude.Left err)
+                                                  -> Prelude.Left (Prelude.show err)
+                                                (Prelude.Right r) -> Prelude.Right r))
+                                       "text"
+                                loop
+                                  (Lens.Family2.set (Data.ProtoLens.Field.field @"text") y x)
+                                  mutable'occurrences mutable'symbols
                         wire
                           -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                         wire
@@ -1119,8 +1152,23 @@ instance Data.ProtoLens.Message Document where
                                             (Data.ProtoLens.Encoding.Bytes.putBytes bs))
                                     Data.ProtoLens.encodeMessage _v))
                          (Lens.Family2.view (Data.ProtoLens.Field.field @"vec'symbols") _x))
-                      (Data.ProtoLens.Encoding.Wire.buildFieldSet
-                         (Lens.Family2.view Data.ProtoLens.unknownFields _x)))))
+                      ((Data.Monoid.<>)
+                         (let _v = Lens.Family2.view (Data.ProtoLens.Field.field @"text") _x
+                          in
+                            if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                                Data.Monoid.mempty
+                            else
+                                (Data.Monoid.<>)
+                                  (Data.ProtoLens.Encoding.Bytes.putVarInt 42)
+                                  ((Prelude..)
+                                     (\ bs
+                                        -> (Data.Monoid.<>)
+                                             (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                             (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                     Data.Text.Encoding.encodeUtf8 _v))
+                         (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                            (Lens.Family2.view Data.ProtoLens.unknownFields _x))))))
 instance Control.DeepSeq.NFData Document where
   rnf
     = \ x__
@@ -1132,7 +1180,9 @@ instance Control.DeepSeq.NFData Document where
                    (_Document'relativePath x__)
                    (Control.DeepSeq.deepseq
                       (_Document'occurrences x__)
-                      (Control.DeepSeq.deepseq (_Document'symbols x__) ()))))
+                      (Control.DeepSeq.deepseq
+                         (_Document'symbols x__)
+                         (Control.DeepSeq.deepseq (_Document'text x__) ())))))
 {- | Fields :
      
          * 'Proto.Scip_Fields.metadata' @:: Lens' Index Metadata@
@@ -3797,12 +3847,17 @@ instance Control.DeepSeq.NFData Symbol where
          * 'Proto.Scip_Fields.vec'documentation' @:: Lens' SymbolInformation (Data.Vector.Vector Data.Text.Text)@
          * 'Proto.Scip_Fields.relationships' @:: Lens' SymbolInformation [Relationship]@
          * 'Proto.Scip_Fields.vec'relationships' @:: Lens' SymbolInformation (Data.Vector.Vector Relationship)@
-         * 'Proto.Scip_Fields.kind' @:: Lens' SymbolInformation SymbolInformation'Kind@ -}
+         * 'Proto.Scip_Fields.kind' @:: Lens' SymbolInformation SymbolInformation'Kind@
+         * 'Proto.Scip_Fields.displayName' @:: Lens' SymbolInformation Data.Text.Text@
+         * 'Proto.Scip_Fields.signatureDocumentation' @:: Lens' SymbolInformation Document@
+         * 'Proto.Scip_Fields.maybe'signatureDocumentation' @:: Lens' SymbolInformation (Prelude.Maybe Document)@ -}
 data SymbolInformation
   = SymbolInformation'_constructor {_SymbolInformation'symbol :: !Data.Text.Text,
                                     _SymbolInformation'documentation :: !(Data.Vector.Vector Data.Text.Text),
                                     _SymbolInformation'relationships :: !(Data.Vector.Vector Relationship),
                                     _SymbolInformation'kind :: !SymbolInformation'Kind,
+                                    _SymbolInformation'displayName :: !Data.Text.Text,
+                                    _SymbolInformation'signatureDocumentation :: !(Prelude.Maybe Document),
                                     _SymbolInformation'_unknownFields :: !Data.ProtoLens.FieldSet}
   deriving stock (Prelude.Eq, Prelude.Ord)
 instance Prelude.Show SymbolInformation where
@@ -3857,6 +3912,29 @@ instance Data.ProtoLens.Field.HasField SymbolInformation "kind" SymbolInformatio
            _SymbolInformation'kind
            (\ x__ y__ -> x__ {_SymbolInformation'kind = y__}))
         Prelude.id
+instance Data.ProtoLens.Field.HasField SymbolInformation "displayName" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _SymbolInformation'displayName
+           (\ x__ y__ -> x__ {_SymbolInformation'displayName = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField SymbolInformation "signatureDocumentation" Document where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _SymbolInformation'signatureDocumentation
+           (\ x__ y__
+              -> x__ {_SymbolInformation'signatureDocumentation = y__}))
+        (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+instance Data.ProtoLens.Field.HasField SymbolInformation "maybe'signatureDocumentation" (Prelude.Maybe Document) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _SymbolInformation'signatureDocumentation
+           (\ x__ y__
+              -> x__ {_SymbolInformation'signatureDocumentation = y__}))
+        Prelude.id
 instance Data.ProtoLens.Message SymbolInformation where
   messageName _ = Data.Text.pack "scip.SymbolInformation"
   packedMessageDescriptor _
@@ -3865,7 +3943,9 @@ instance Data.ProtoLens.Message SymbolInformation where
       \\ACKsymbol\CAN\SOH \SOH(\tR\ACKsymbol\DC2$\n\
       \\rdocumentation\CAN\ETX \ETX(\tR\rdocumentation\DC28\n\
       \\rrelationships\CAN\EOT \ETX(\v2\DC2.scip.RelationshipR\rrelationships\DC20\n\
-      \\EOTkind\CAN\ENQ \SOH(\SO2\FS.scip.SymbolInformation.KindR\EOTkind\"\218\ACK\n\
+      \\EOTkind\CAN\ENQ \SOH(\SO2\FS.scip.SymbolInformation.KindR\EOTkind\DC2!\n\
+      \\fdisplay_name\CAN\ACK \SOH(\tR\vdisplayName\DC2G\n\
+      \\ETBsignature_documentation\CAN\a \SOH(\v2\SO.scip.DocumentR\SYNsignatureDocumentation\"\218\ACK\n\
       \\EOTKind\DC2\DC3\n\
       \\SIUnspecifiedKind\DLE\NUL\DC2\t\n\
       \\ENQArray\DLE\SOH\DC2\r\n\
@@ -3979,12 +4059,31 @@ instance Data.ProtoLens.Message SymbolInformation where
               (Data.ProtoLens.PlainField
                  Data.ProtoLens.Optional (Data.ProtoLens.Field.field @"kind")) ::
               Data.ProtoLens.FieldDescriptor SymbolInformation
+        displayName__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "display_name"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional
+                 (Data.ProtoLens.Field.field @"displayName")) ::
+              Data.ProtoLens.FieldDescriptor SymbolInformation
+        signatureDocumentation__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "signature_documentation"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor Document)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'signatureDocumentation")) ::
+              Data.ProtoLens.FieldDescriptor SymbolInformation
       in
         Data.Map.fromList
           [(Data.ProtoLens.Tag 1, symbol__field_descriptor),
            (Data.ProtoLens.Tag 3, documentation__field_descriptor),
            (Data.ProtoLens.Tag 4, relationships__field_descriptor),
-           (Data.ProtoLens.Tag 5, kind__field_descriptor)]
+           (Data.ProtoLens.Tag 5, kind__field_descriptor),
+           (Data.ProtoLens.Tag 6, displayName__field_descriptor),
+           (Data.ProtoLens.Tag 7, signatureDocumentation__field_descriptor)]
   unknownFields
     = Lens.Family2.Unchecked.lens
         _SymbolInformation'_unknownFields
@@ -3995,6 +4094,8 @@ instance Data.ProtoLens.Message SymbolInformation where
          _SymbolInformation'documentation = Data.Vector.Generic.empty,
          _SymbolInformation'relationships = Data.Vector.Generic.empty,
          _SymbolInformation'kind = Data.ProtoLens.fieldDefault,
+         _SymbolInformation'displayName = Data.ProtoLens.fieldDefault,
+         _SymbolInformation'signatureDocumentation = Prelude.Nothing,
          _SymbolInformation'_unknownFields = []}
   parseMessage
     = let
@@ -4084,6 +4185,30 @@ instance Data.ProtoLens.Message SymbolInformation where
                                 loop
                                   (Lens.Family2.set (Data.ProtoLens.Field.field @"kind") y x)
                                   mutable'documentation mutable'relationships
+                        50
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                       Data.ProtoLens.Encoding.Bytes.getBytes
+                                                         (Prelude.fromIntegral len)
+                                           Data.ProtoLens.Encoding.Bytes.runEither
+                                             (case Data.Text.Encoding.decodeUtf8' value of
+                                                (Prelude.Left err)
+                                                  -> Prelude.Left (Prelude.show err)
+                                                (Prelude.Right r) -> Prelude.Right r))
+                                       "display_name"
+                                loop
+                                  (Lens.Family2.set (Data.ProtoLens.Field.field @"displayName") y x)
+                                  mutable'documentation mutable'relationships
+                        58
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.isolate
+                                             (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
+                                       "signature_documentation"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"signatureDocumentation") y x)
+                                  mutable'documentation mutable'relationships
                         wire
                           -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                         wire
@@ -4159,8 +4284,42 @@ instance Data.ProtoLens.Message SymbolInformation where
                                   ((Prelude..)
                                      Data.ProtoLens.Encoding.Bytes.putVarInt Prelude.fromIntegral)
                                   Prelude.fromEnum _v))
-                      (Data.ProtoLens.Encoding.Wire.buildFieldSet
-                         (Lens.Family2.view Data.ProtoLens.unknownFields _x)))))
+                      ((Data.Monoid.<>)
+                         (let
+                            _v
+                              = Lens.Family2.view (Data.ProtoLens.Field.field @"displayName") _x
+                          in
+                            if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                                Data.Monoid.mempty
+                            else
+                                (Data.Monoid.<>)
+                                  (Data.ProtoLens.Encoding.Bytes.putVarInt 50)
+                                  ((Prelude..)
+                                     (\ bs
+                                        -> (Data.Monoid.<>)
+                                             (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                             (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                     Data.Text.Encoding.encodeUtf8 _v))
+                         ((Data.Monoid.<>)
+                            (case
+                                 Lens.Family2.view
+                                   (Data.ProtoLens.Field.field @"maybe'signatureDocumentation") _x
+                             of
+                               Prelude.Nothing -> Data.Monoid.mempty
+                               (Prelude.Just _v)
+                                 -> (Data.Monoid.<>)
+                                      (Data.ProtoLens.Encoding.Bytes.putVarInt 58)
+                                      ((Prelude..)
+                                         (\ bs
+                                            -> (Data.Monoid.<>)
+                                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                    (Prelude.fromIntegral
+                                                       (Data.ByteString.length bs)))
+                                                 (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                         Data.ProtoLens.encodeMessage _v))
+                            (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                               (Lens.Family2.view Data.ProtoLens.unknownFields _x)))))))
 instance Control.DeepSeq.NFData SymbolInformation where
   rnf
     = \ x__
@@ -4172,7 +4331,12 @@ instance Control.DeepSeq.NFData SymbolInformation where
                    (_SymbolInformation'documentation x__)
                    (Control.DeepSeq.deepseq
                       (_SymbolInformation'relationships x__)
-                      (Control.DeepSeq.deepseq (_SymbolInformation'kind x__) ()))))
+                      (Control.DeepSeq.deepseq
+                         (_SymbolInformation'kind x__)
+                         (Control.DeepSeq.deepseq
+                            (_SymbolInformation'displayName x__)
+                            (Control.DeepSeq.deepseq
+                               (_SymbolInformation'signatureDocumentation x__) ()))))))
 newtype SymbolInformation'Kind'UnrecognizedValue
   = SymbolInformation'Kind'UnrecognizedValue Data.Int.Int32
   deriving stock (Prelude.Eq, Prelude.Ord, Prelude.Show)
@@ -5436,12 +5600,13 @@ packedFileDescriptor
     \\bToolInfo\DC2\DC2\n\
     \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2\CAN\n\
     \\aversion\CAN\STX \SOH(\tR\aversion\DC2\FS\n\
-    \\targuments\CAN\ETX \ETX(\tR\targuments\"\178\SOH\n\
+    \\targuments\CAN\ETX \ETX(\tR\targuments\"\198\SOH\n\
     \\bDocument\DC2\SUB\n\
     \\blanguage\CAN\EOT \SOH(\tR\blanguage\DC2#\n\
     \\rrelative_path\CAN\SOH \SOH(\tR\frelativePath\DC22\n\
     \\voccurrences\CAN\STX \ETX(\v2\DLE.scip.OccurrenceR\voccurrences\DC21\n\
-    \\asymbols\CAN\ETX \ETX(\v2\ETB.scip.SymbolInformationR\asymbols\"}\n\
+    \\asymbols\CAN\ETX \ETX(\v2\ETB.scip.SymbolInformationR\asymbols\DC2\DC2\n\
+    \\EOTtext\CAN\ENQ \SOH(\tR\EOTtext\"}\n\
     \\ACKSymbol\DC2\SYN\n\
     \\ACKscheme\CAN\SOH \SOH(\tR\ACKscheme\DC2'\n\
     \\apackage\CAN\STX \SOH(\v2\r.scip.PackageR\apackage\DC22\n\
@@ -5467,12 +5632,14 @@ packedFileDescriptor
     \\tParameter\DLE\ACK\DC2\b\n\
     \\EOTMeta\DLE\a\DC2\t\n\
     \\ENQLocal\DLE\b\DC2\t\n\
-    \\ENQMacro\DLE\t\SUB\STX\DLE\SOH\"\154\b\n\
+    \\ENQMacro\DLE\t\SUB\STX\DLE\SOH\"\134\t\n\
     \\DC1SymbolInformation\DC2\SYN\n\
     \\ACKsymbol\CAN\SOH \SOH(\tR\ACKsymbol\DC2$\n\
     \\rdocumentation\CAN\ETX \ETX(\tR\rdocumentation\DC28\n\
     \\rrelationships\CAN\EOT \ETX(\v2\DC2.scip.RelationshipR\rrelationships\DC20\n\
-    \\EOTkind\CAN\ENQ \SOH(\SO2\FS.scip.SymbolInformation.KindR\EOTkind\"\218\ACK\n\
+    \\EOTkind\CAN\ENQ \SOH(\SO2\FS.scip.SymbolInformation.KindR\EOTkind\DC2!\n\
+    \\fdisplay_name\CAN\ACK \SOH(\tR\vdisplayName\DC2G\n\
+    \\ETBsignature_documentation\CAN\a \SOH(\v2\SO.scip.DocumentR\SYNsignatureDocumentation\"\218\ACK\n\
     \\EOTKind\DC2\DC3\n\
     \\SIUnspecifiedKind\DLE\NUL\DC2\t\n\
     \\ENQArray\DLE\SOH\DC2\r\n\
@@ -5762,9 +5929,9 @@ packedFileDescriptor
     \\ETXXML\DLE\US\DC2\a\n\
     \\ETXXSL\DLE \DC2\b\n\
     \\EOTYAML\DLEJ\DC2\a\n\
-    \\ETXZig\DLE&B/Z-github.com/sourcegraph/scip/bindings/go/scip/J\186\245\SOH\n\
+    \\ETXZig\DLE&B/Z-github.com/sourcegraph/scip/bindings/go/scip/J\255\130\STX\n\
     \\a\DC2\ENQ\n\
-    \\NUL\191\ENQ\SOH\n\
+    \\NUL\219\ENQ\SOH\n\
     \\130\EOT\n\
     \\SOH\f\DC2\ETX\n\
     \\NUL\DC22\247\ETX An index contains one or more pieces of information about a given piece of\n\
@@ -5953,7 +6120,7 @@ packedFileDescriptor
     \\f\n\
     \\ENQ\EOT\STX\STX\STX\ETX\DC2\ETXA\RS\US\n\
     \H\n\
-    \\STX\EOT\ETX\DC2\EOTE\NUL]\SOH\SUB< Document defines the metadata about a source file on disk.\n\
+    \\STX\EOT\ETX\DC2\EOTE\NULf\SOH\SUB< Document defines the metadata about a source file on disk.\n\
     \\n\
     \\n\
     \\n\
@@ -6015,8 +6182,23 @@ packedFileDescriptor
     \\ENQ\EOT\ETX\STX\ETX\SOH\DC2\ETX\\\GS$\n\
     \\f\n\
     \\ENQ\EOT\ETX\STX\ETX\ETX\DC2\ETX\\'(\n\
+    \\247\ETX\n\
+    \\EOT\EOT\ETX\STX\EOT\DC2\ETXe\STX\DC2\SUB\233\ETX (optional) Text contents of the this document. Indexers are not expected to\n\
+    \ include the text by default. It's preferrable that clients read the text\n\
+    \ contents from the file system by resolving the absolute path from joining\n\
+    \ `Index.metadata.project_root` and `Document.relative_path`. This field was\n\
+    \ introduced to support `SymbolInformation.signature_documentation`, but it\n\
+    \ can be used for other purposes as well, for example testing or when working\n\
+    \ with virtual/in-memory documents.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\ETX\STX\EOT\ENQ\DC2\ETXe\STX\b\n\
+    \\f\n\
+    \\ENQ\EOT\ETX\STX\EOT\SOH\DC2\ETXe\t\r\n\
+    \\f\n\
+    \\ENQ\EOT\ETX\STX\EOT\ETX\DC2\ETXe\DLE\DC1\n\
     \\243\SI\n\
-    \\STX\EOT\EOT\DC2\ACK\133\SOH\NUL\137\SOH\SOH\SUB\228\SI Symbol is similar to a URI, it identifies a class, method, or a local\n\
+    \\STX\EOT\EOT\DC2\ACK\142\SOH\NUL\146\SOH\SOH\SUB\228\SI Symbol is similar to a URI, it identifies a class, method, or a local\n\
     \ variable. `SymbolInformation` contains rich metadata about symbols such as\n\
     \ the docstring.\n\
     \\n\
@@ -6055,237 +6237,239 @@ packedFileDescriptor
     \ the file and the node corresponding to the symbol.\n\
     \\n\
     \\v\n\
-    \\ETX\EOT\EOT\SOH\DC2\EOT\133\SOH\b\SO\n\
+    \\ETX\EOT\EOT\SOH\DC2\EOT\142\SOH\b\SO\n\
     \\f\n\
-    \\EOT\EOT\EOT\STX\NUL\DC2\EOT\134\SOH\STX\DC4\n\
+    \\EOT\EOT\EOT\STX\NUL\DC2\EOT\143\SOH\STX\DC4\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\NUL\ENQ\DC2\EOT\134\SOH\STX\b\n\
+    \\ENQ\EOT\EOT\STX\NUL\ENQ\DC2\EOT\143\SOH\STX\b\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\NUL\SOH\DC2\EOT\134\SOH\t\SI\n\
+    \\ENQ\EOT\EOT\STX\NUL\SOH\DC2\EOT\143\SOH\t\SI\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\NUL\ETX\DC2\EOT\134\SOH\DC2\DC3\n\
+    \\ENQ\EOT\EOT\STX\NUL\ETX\DC2\EOT\143\SOH\DC2\DC3\n\
     \\f\n\
-    \\EOT\EOT\EOT\STX\SOH\DC2\EOT\135\SOH\STX\SYN\n\
+    \\EOT\EOT\EOT\STX\SOH\DC2\EOT\144\SOH\STX\SYN\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\SOH\ACK\DC2\EOT\135\SOH\STX\t\n\
+    \\ENQ\EOT\EOT\STX\SOH\ACK\DC2\EOT\144\SOH\STX\t\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\SOH\SOH\DC2\EOT\135\SOH\n\
+    \\ENQ\EOT\EOT\STX\SOH\SOH\DC2\EOT\144\SOH\n\
     \\DC1\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\SOH\ETX\DC2\EOT\135\SOH\DC4\NAK\n\
+    \\ENQ\EOT\EOT\STX\SOH\ETX\DC2\EOT\144\SOH\DC4\NAK\n\
     \\f\n\
-    \\EOT\EOT\EOT\STX\STX\DC2\EOT\136\SOH\STX&\n\
+    \\EOT\EOT\EOT\STX\STX\DC2\EOT\145\SOH\STX&\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\STX\EOT\DC2\EOT\136\SOH\STX\n\
+    \\ENQ\EOT\EOT\STX\STX\EOT\DC2\EOT\145\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\STX\ACK\DC2\EOT\136\SOH\v\NAK\n\
+    \\ENQ\EOT\EOT\STX\STX\ACK\DC2\EOT\145\SOH\v\NAK\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\STX\SOH\DC2\EOT\136\SOH\SYN!\n\
+    \\ENQ\EOT\EOT\STX\STX\SOH\DC2\EOT\145\SOH\SYN!\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\STX\ETX\DC2\EOT\136\SOH$%\n\
+    \\ENQ\EOT\EOT\STX\STX\ETX\DC2\EOT\145\SOH$%\n\
     \q\n\
-    \\STX\EOT\ENQ\DC2\ACK\142\SOH\NUL\146\SOH\SOH\SUBc Unit of packaging and distribution.\n\
+    \\STX\EOT\ENQ\DC2\ACK\151\SOH\NUL\155\SOH\SOH\SUBc Unit of packaging and distribution.\n\
     \\n\
     \ NOTE: This corresponds to a module in Go and JVM languages.\n\
     \\n\
     \\v\n\
-    \\ETX\EOT\ENQ\SOH\DC2\EOT\142\SOH\b\SI\n\
+    \\ETX\EOT\ENQ\SOH\DC2\EOT\151\SOH\b\SI\n\
     \\f\n\
-    \\EOT\EOT\ENQ\STX\NUL\DC2\EOT\143\SOH\STX\NAK\n\
+    \\EOT\EOT\ENQ\STX\NUL\DC2\EOT\152\SOH\STX\NAK\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\NUL\ENQ\DC2\EOT\143\SOH\STX\b\n\
+    \\ENQ\EOT\ENQ\STX\NUL\ENQ\DC2\EOT\152\SOH\STX\b\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\NUL\SOH\DC2\EOT\143\SOH\t\DLE\n\
+    \\ENQ\EOT\ENQ\STX\NUL\SOH\DC2\EOT\152\SOH\t\DLE\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\NUL\ETX\DC2\EOT\143\SOH\DC3\DC4\n\
+    \\ENQ\EOT\ENQ\STX\NUL\ETX\DC2\EOT\152\SOH\DC3\DC4\n\
     \\f\n\
-    \\EOT\EOT\ENQ\STX\SOH\DC2\EOT\144\SOH\STX\DC2\n\
+    \\EOT\EOT\ENQ\STX\SOH\DC2\EOT\153\SOH\STX\DC2\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\SOH\ENQ\DC2\EOT\144\SOH\STX\b\n\
+    \\ENQ\EOT\ENQ\STX\SOH\ENQ\DC2\EOT\153\SOH\STX\b\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\SOH\SOH\DC2\EOT\144\SOH\t\r\n\
+    \\ENQ\EOT\ENQ\STX\SOH\SOH\DC2\EOT\153\SOH\t\r\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\SOH\ETX\DC2\EOT\144\SOH\DLE\DC1\n\
+    \\ENQ\EOT\ENQ\STX\SOH\ETX\DC2\EOT\153\SOH\DLE\DC1\n\
     \\f\n\
-    \\EOT\EOT\ENQ\STX\STX\DC2\EOT\145\SOH\STX\NAK\n\
+    \\EOT\EOT\ENQ\STX\STX\DC2\EOT\154\SOH\STX\NAK\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\STX\ENQ\DC2\EOT\145\SOH\STX\b\n\
+    \\ENQ\EOT\ENQ\STX\STX\ENQ\DC2\EOT\154\SOH\STX\b\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\STX\SOH\DC2\EOT\145\SOH\t\DLE\n\
+    \\ENQ\EOT\ENQ\STX\STX\SOH\DC2\EOT\154\SOH\t\DLE\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\STX\ETX\DC2\EOT\145\SOH\DC3\DC4\n\
+    \\ENQ\EOT\ENQ\STX\STX\ETX\DC2\EOT\154\SOH\DC3\DC4\n\
     \\f\n\
-    \\STX\EOT\ACK\DC2\ACK\148\SOH\NUL\171\SOH\SOH\n\
+    \\STX\EOT\ACK\DC2\ACK\157\SOH\NUL\180\SOH\SOH\n\
     \\v\n\
-    \\ETX\EOT\ACK\SOH\DC2\EOT\148\SOH\b\DC2\n\
+    \\ETX\EOT\ACK\SOH\DC2\EOT\157\SOH\b\DC2\n\
     \\SO\n\
-    \\EOT\EOT\ACK\EOT\NUL\DC2\ACK\149\SOH\STX\167\SOH\ETX\n\
+    \\EOT\EOT\ACK\EOT\NUL\DC2\ACK\158\SOH\STX\176\SOH\ETX\n\
     \\r\n\
-    \\ENQ\EOT\ACK\EOT\NUL\SOH\DC2\EOT\149\SOH\a\r\n\
+    \\ENQ\EOT\ACK\EOT\NUL\SOH\DC2\EOT\158\SOH\a\r\n\
     \\r\n\
-    \\ENQ\EOT\ACK\EOT\NUL\ETX\DC2\EOT\150\SOH\EOT\RS\n\
+    \\ENQ\EOT\ACK\EOT\NUL\ETX\DC2\EOT\159\SOH\EOT\RS\n\
     \\SO\n\
-    \\ACK\EOT\ACK\EOT\NUL\ETX\STX\DC2\EOT\150\SOH\EOT\RS\n\
+    \\ACK\EOT\ACK\EOT\NUL\ETX\STX\DC2\EOT\159\SOH\EOT\RS\n\
     \\SO\n\
-    \\ACK\EOT\ACK\EOT\NUL\STX\NUL\DC2\EOT\151\SOH\EOT\SUB\n\
+    \\ACK\EOT\ACK\EOT\NUL\STX\NUL\DC2\EOT\160\SOH\EOT\SUB\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\NUL\SOH\DC2\EOT\151\SOH\EOT\NAK\n\
+    \\a\EOT\ACK\EOT\NUL\STX\NUL\SOH\DC2\EOT\160\SOH\EOT\NAK\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\NUL\STX\DC2\EOT\151\SOH\CAN\EM\n\
+    \\a\EOT\ACK\EOT\NUL\STX\NUL\STX\DC2\EOT\160\SOH\CAN\EM\n\
     \}\n\
-    \\ACK\EOT\ACK\EOT\NUL\STX\SOH\DC2\EOT\155\SOH\EOT\DC2\SUBm Unit of code abstraction and/or namespacing.\n\
+    \\ACK\EOT\ACK\EOT\NUL\STX\SOH\DC2\EOT\164\SOH\EOT\DC2\SUBm Unit of code abstraction and/or namespacing.\n\
     \\n\
     \ NOTE: This corresponds to a package in Go and JVM languages.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\SOH\SOH\DC2\EOT\155\SOH\EOT\r\n\
+    \\a\EOT\ACK\EOT\NUL\STX\SOH\SOH\DC2\EOT\164\SOH\EOT\r\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\SOH\STX\DC2\EOT\155\SOH\DLE\DC1\n\
+    \\a\EOT\ACK\EOT\NUL\STX\SOH\STX\DC2\EOT\164\SOH\DLE\DC1\n\
     \(\n\
-    \\ACK\EOT\ACK\EOT\NUL\STX\STX\DC2\EOT\157\SOH\EOT\"\SUB\CAN Use Namespace instead.\n\
+    \\ACK\EOT\ACK\EOT\NUL\STX\STX\DC2\EOT\166\SOH\EOT\"\SUB\CAN Use Namespace instead.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\STX\SOH\DC2\EOT\157\SOH\EOT\v\n\
+    \\a\EOT\ACK\EOT\NUL\STX\STX\SOH\DC2\EOT\166\SOH\EOT\v\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\STX\STX\DC2\EOT\157\SOH\SO\SI\n\
+    \\a\EOT\ACK\EOT\NUL\STX\STX\STX\DC2\EOT\166\SOH\SO\SI\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\STX\ETX\DC2\EOT\157\SOH\DLE!\n\
+    \\a\EOT\ACK\EOT\NUL\STX\STX\ETX\DC2\EOT\166\SOH\DLE!\n\
     \\DLE\n\
-    \\b\EOT\ACK\EOT\NUL\STX\STX\ETX\SOH\DC2\EOT\157\SOH\DC1 \n\
+    \\b\EOT\ACK\EOT\NUL\STX\STX\ETX\SOH\DC2\EOT\166\SOH\DC1 \n\
     \\SO\n\
-    \\ACK\EOT\ACK\EOT\NUL\STX\ETX\DC2\EOT\158\SOH\EOT\r\n\
+    \\ACK\EOT\ACK\EOT\NUL\STX\ETX\DC2\EOT\167\SOH\EOT\r\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\ETX\SOH\DC2\EOT\158\SOH\EOT\b\n\
+    \\a\EOT\ACK\EOT\NUL\STX\ETX\SOH\DC2\EOT\167\SOH\EOT\b\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\ETX\STX\DC2\EOT\158\SOH\v\f\n\
+    \\a\EOT\ACK\EOT\NUL\STX\ETX\STX\DC2\EOT\167\SOH\v\f\n\
     \\SO\n\
-    \\ACK\EOT\ACK\EOT\NUL\STX\EOT\DC2\EOT\159\SOH\EOT\r\n\
+    \\ACK\EOT\ACK\EOT\NUL\STX\EOT\DC2\EOT\168\SOH\EOT\r\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\EOT\SOH\DC2\EOT\159\SOH\EOT\b\n\
+    \\a\EOT\ACK\EOT\NUL\STX\EOT\SOH\DC2\EOT\168\SOH\EOT\b\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\EOT\STX\DC2\EOT\159\SOH\v\f\n\
+    \\a\EOT\ACK\EOT\NUL\STX\EOT\STX\DC2\EOT\168\SOH\v\f\n\
     \\SO\n\
-    \\ACK\EOT\ACK\EOT\NUL\STX\ENQ\DC2\EOT\160\SOH\EOT\SI\n\
+    \\ACK\EOT\ACK\EOT\NUL\STX\ENQ\DC2\EOT\169\SOH\EOT\SI\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\ENQ\SOH\DC2\EOT\160\SOH\EOT\n\
+    \\a\EOT\ACK\EOT\NUL\STX\ENQ\SOH\DC2\EOT\169\SOH\EOT\n\
     \\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\ENQ\STX\DC2\EOT\160\SOH\r\SO\n\
+    \\a\EOT\ACK\EOT\NUL\STX\ENQ\STX\DC2\EOT\169\SOH\r\SO\n\
     \\SO\n\
-    \\ACK\EOT\ACK\EOT\NUL\STX\ACK\DC2\EOT\161\SOH\EOT\SYN\n\
+    \\ACK\EOT\ACK\EOT\NUL\STX\ACK\DC2\EOT\170\SOH\EOT\SYN\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\ACK\SOH\DC2\EOT\161\SOH\EOT\DC1\n\
+    \\a\EOT\ACK\EOT\NUL\STX\ACK\SOH\DC2\EOT\170\SOH\EOT\DC1\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\ACK\STX\DC2\EOT\161\SOH\DC4\NAK\n\
+    \\a\EOT\ACK\EOT\NUL\STX\ACK\STX\DC2\EOT\170\SOH\DC4\NAK\n\
     \\SO\n\
-    \\ACK\EOT\ACK\EOT\NUL\STX\a\DC2\EOT\162\SOH\EOT\DC2\n\
+    \\ACK\EOT\ACK\EOT\NUL\STX\a\DC2\EOT\171\SOH\EOT\DC2\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\a\SOH\DC2\EOT\162\SOH\EOT\r\n\
+    \\a\EOT\ACK\EOT\NUL\STX\a\SOH\DC2\EOT\171\SOH\EOT\r\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\a\STX\DC2\EOT\162\SOH\DLE\DC1\n\
+    \\a\EOT\ACK\EOT\NUL\STX\a\STX\DC2\EOT\171\SOH\DLE\DC1\n\
     \.\n\
-    \\ACK\EOT\ACK\EOT\NUL\STX\b\DC2\EOT\164\SOH\EOT\r\SUB\RS Can be used for any purpose.\n\
+    \\ACK\EOT\ACK\EOT\NUL\STX\b\DC2\EOT\173\SOH\EOT\r\SUB\RS Can be used for any purpose.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\b\SOH\DC2\EOT\164\SOH\EOT\b\n\
+    \\a\EOT\ACK\EOT\NUL\STX\b\SOH\DC2\EOT\173\SOH\EOT\b\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\b\STX\DC2\EOT\164\SOH\v\f\n\
+    \\a\EOT\ACK\EOT\NUL\STX\b\STX\DC2\EOT\173\SOH\v\f\n\
     \\SO\n\
-    \\ACK\EOT\ACK\EOT\NUL\STX\t\DC2\EOT\165\SOH\EOT\SO\n\
+    \\ACK\EOT\ACK\EOT\NUL\STX\t\DC2\EOT\174\SOH\EOT\SO\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\t\SOH\DC2\EOT\165\SOH\EOT\t\n\
+    \\a\EOT\ACK\EOT\NUL\STX\t\SOH\DC2\EOT\174\SOH\EOT\t\n\
     \\SI\n\
-    \\a\EOT\ACK\EOT\NUL\STX\t\STX\DC2\EOT\165\SOH\f\r\n\
+    \\a\EOT\ACK\EOT\NUL\STX\t\STX\DC2\EOT\174\SOH\f\r\n\
     \\SO\n\
     \\ACK\EOT\ACK\EOT\NUL\STX\n\
-    \\DC2\EOT\166\SOH\EOT\SO\n\
+    \\DC2\EOT\175\SOH\EOT\SO\n\
     \\SI\n\
     \\a\EOT\ACK\EOT\NUL\STX\n\
-    \\SOH\DC2\EOT\166\SOH\EOT\t\n\
+    \\SOH\DC2\EOT\175\SOH\EOT\t\n\
     \\SI\n\
     \\a\EOT\ACK\EOT\NUL\STX\n\
-    \\STX\DC2\EOT\166\SOH\f\r\n\
+    \\STX\DC2\EOT\175\SOH\f\r\n\
     \\f\n\
-    \\EOT\EOT\ACK\STX\NUL\DC2\EOT\168\SOH\STX\DC2\n\
+    \\EOT\EOT\ACK\STX\NUL\DC2\EOT\177\SOH\STX\DC2\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\NUL\ENQ\DC2\EOT\168\SOH\STX\b\n\
+    \\ENQ\EOT\ACK\STX\NUL\ENQ\DC2\EOT\177\SOH\STX\b\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\NUL\SOH\DC2\EOT\168\SOH\t\r\n\
+    \\ENQ\EOT\ACK\STX\NUL\SOH\DC2\EOT\177\SOH\t\r\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\NUL\ETX\DC2\EOT\168\SOH\DLE\DC1\n\
+    \\ENQ\EOT\ACK\STX\NUL\ETX\DC2\EOT\177\SOH\DLE\DC1\n\
     \\f\n\
-    \\EOT\EOT\ACK\STX\SOH\DC2\EOT\169\SOH\STX\ESC\n\
+    \\EOT\EOT\ACK\STX\SOH\DC2\EOT\178\SOH\STX\ESC\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\SOH\ENQ\DC2\EOT\169\SOH\STX\b\n\
+    \\ENQ\EOT\ACK\STX\SOH\ENQ\DC2\EOT\178\SOH\STX\b\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\SOH\SOH\DC2\EOT\169\SOH\t\SYN\n\
+    \\ENQ\EOT\ACK\STX\SOH\SOH\DC2\EOT\178\SOH\t\SYN\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\SOH\ETX\DC2\EOT\169\SOH\EM\SUB\n\
+    \\ENQ\EOT\ACK\STX\SOH\ETX\DC2\EOT\178\SOH\EM\SUB\n\
     \\f\n\
-    \\EOT\EOT\ACK\STX\STX\DC2\EOT\170\SOH\STX\DC4\n\
+    \\EOT\EOT\ACK\STX\STX\DC2\EOT\179\SOH\STX\DC4\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\STX\ACK\DC2\EOT\170\SOH\STX\b\n\
+    \\ENQ\EOT\ACK\STX\STX\ACK\DC2\EOT\179\SOH\STX\b\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\STX\SOH\DC2\EOT\170\SOH\t\SI\n\
+    \\ENQ\EOT\ACK\STX\STX\SOH\DC2\EOT\179\SOH\t\SI\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\STX\ETX\DC2\EOT\170\SOH\DC2\DC3\n\
+    \\ENQ\EOT\ACK\STX\STX\ETX\DC2\EOT\179\SOH\DC2\DC3\n\
     \\131\SOH\n\
-    \\STX\EOT\a\DC2\ACK\175\SOH\NUL\173\STX\SOH\SUBu SymbolInformation defines metadata about a symbol, such as the symbol's\n\
+    \\STX\EOT\a\DC2\ACK\184\SOH\NUL\201\STX\SOH\SUBu SymbolInformation defines metadata about a symbol, such as the symbol's\n\
     \ docstring or what package it's defined it.\n\
     \\n\
     \\v\n\
-    \\ETX\EOT\a\SOH\DC2\EOT\175\SOH\b\EM\n\
+    \\ETX\EOT\a\SOH\DC2\EOT\184\SOH\b\EM\n\
     \\160\SOH\n\
-    \\EOT\EOT\a\STX\NUL\DC2\EOT\178\SOH\STX\DC4\SUB\145\SOH Identifier of this symbol, which can be referenced from `Occurence.symbol`.\n\
+    \\EOT\EOT\a\STX\NUL\DC2\EOT\187\SOH\STX\DC4\SUB\145\SOH Identifier of this symbol, which can be referenced from `Occurence.symbol`.\n\
     \ The string must be formatted according to the grammar in `Symbol`.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\NUL\ENQ\DC2\EOT\178\SOH\STX\b\n\
+    \\ENQ\EOT\a\STX\NUL\ENQ\DC2\EOT\187\SOH\STX\b\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\NUL\SOH\DC2\EOT\178\SOH\t\SI\n\
+    \\ENQ\EOT\a\STX\NUL\SOH\DC2\EOT\187\SOH\t\SI\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\NUL\ETX\DC2\EOT\178\SOH\DC2\DC3\n\
-    \\181\STX\n\
-    \\EOT\EOT\a\STX\SOH\DC2\EOT\183\SOH\STX$\SUB\166\STX (optional, but strongly recommended) The markdown-formatted documentation\n\
-    \ for this symbol. This field is repeated to allow different kinds of\n\
-    \ documentation. For example, it's nice to include both the signature of a\n\
-    \ method (parameters and return type) along with the accompanying docstring.\n\
+    \\ENQ\EOT\a\STX\NUL\ETX\DC2\EOT\187\SOH\DC2\DC3\n\
+    \\180\ETX\n\
+    \\EOT\EOT\a\STX\SOH\DC2\EOT\194\SOH\STX$\SUB\165\ETX (optional, but strongly recommended) The markdown-formatted documentation\n\
+    \ for this symbol. Use `SymbolInformation.signature_documentation` to\n\
+    \ document the method/class/type signature of this symbol.\n\
+    \ Due to historical reasons, indexers may include signature documentation in\n\
+    \ this field by rendering markdown code blocks. New indexers should only\n\
+    \ include non-code documentation in this field, for example docstrings.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\SOH\EOT\DC2\EOT\183\SOH\STX\n\
+    \\ENQ\EOT\a\STX\SOH\EOT\DC2\EOT\194\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\SOH\ENQ\DC2\EOT\183\SOH\v\DC1\n\
+    \\ENQ\EOT\a\STX\SOH\ENQ\DC2\EOT\194\SOH\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\SOH\SOH\DC2\EOT\183\SOH\DC2\US\n\
+    \\ENQ\EOT\a\STX\SOH\SOH\DC2\EOT\194\SOH\DC2\US\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\SOH\ETX\DC2\EOT\183\SOH\"#\n\
+    \\ENQ\EOT\a\STX\SOH\ETX\DC2\EOT\194\SOH\"#\n\
     \^\n\
-    \\EOT\EOT\a\STX\STX\DC2\EOT\185\SOH\STX*\SUBP (optional) Relationships to other symbols (e.g., implements, type definition).\n\
+    \\EOT\EOT\a\STX\STX\DC2\EOT\196\SOH\STX*\SUBP (optional) Relationships to other symbols (e.g., implements, type definition).\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\STX\EOT\DC2\EOT\185\SOH\STX\n\
+    \\ENQ\EOT\a\STX\STX\EOT\DC2\EOT\196\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\STX\ACK\DC2\EOT\185\SOH\v\ETB\n\
+    \\ENQ\EOT\a\STX\STX\ACK\DC2\EOT\196\SOH\v\ETB\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\STX\SOH\DC2\EOT\185\SOH\CAN%\n\
+    \\ENQ\EOT\a\STX\STX\SOH\DC2\EOT\196\SOH\CAN%\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\STX\ETX\DC2\EOT\185\SOH()\n\
+    \\ENQ\EOT\a\STX\STX\ETX\DC2\EOT\196\SOH()\n\
     \\164\SOH\n\
-    \\EOT\EOT\a\STX\ETX\DC2\EOT\189\SOH\STX\DLE\SUB\149\SOH The kind of this symbol. Use this field instead of\n\
+    \\EOT\EOT\a\STX\ETX\DC2\EOT\200\SOH\STX\DLE\SUB\149\SOH The kind of this symbol. Use this field instead of\n\
     \ `SymbolDescriptor.Suffix` to determine whether something is, for example, a\n\
     \ class or a method.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\ETX\ACK\DC2\EOT\189\SOH\STX\ACK\n\
+    \\ENQ\EOT\a\STX\ETX\ACK\DC2\EOT\200\SOH\STX\ACK\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\ETX\SOH\DC2\EOT\189\SOH\a\v\n\
+    \\ENQ\EOT\a\STX\ETX\SOH\DC2\EOT\200\SOH\a\v\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\ETX\ETX\DC2\EOT\189\SOH\SO\SI\n\
-    \\234\ENQ\n\
-    \\EOT\EOT\a\EOT\NUL\DC2\ACK\204\SOH\STX\172\STX\ETX\SUB\217\ENQ Kind represents the fine-grained category of a symbol, suitable for presenting\n\
+    \\ENQ\EOT\a\STX\ETX\ETX\DC2\EOT\200\SOH\SO\SI\n\
+    \\245\ENQ\n\
+    \\EOT\EOT\a\EOT\NUL\DC2\ACK\215\SOH\STX\183\STX\ETX\SUB\228\ENQ (optional) Kind represents the fine-grained category of a symbol, suitable for presenting\n\
     \ information about the symbol's meaning in the language.\n\
     \\n\
     \ For example:\n\
@@ -6301,440 +6485,472 @@ packedFileDescriptor
     \ - If two symbols have different Suffixes, they should have different Kinds.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\a\EOT\NUL\SOH\DC2\EOT\204\SOH\a\v\n\
+    \\ENQ\EOT\a\EOT\NUL\SOH\DC2\EOT\215\SOH\a\v\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\NUL\DC2\EOT\205\SOH\ACK\SUB\n\
+    \\ACK\EOT\a\EOT\NUL\STX\NUL\DC2\EOT\216\SOH\ACK\SUB\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\NUL\SOH\DC2\EOT\205\SOH\ACK\NAK\n\
+    \\a\EOT\a\EOT\NUL\STX\NUL\SOH\DC2\EOT\216\SOH\ACK\NAK\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\NUL\STX\DC2\EOT\205\SOH\CAN\EM\n\
+    \\a\EOT\a\EOT\NUL\STX\NUL\STX\DC2\EOT\216\SOH\CAN\EM\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\SOH\DC2\EOT\206\SOH\ACK\DLE\n\
+    \\ACK\EOT\a\EOT\NUL\STX\SOH\DC2\EOT\217\SOH\ACK\DLE\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\SOH\SOH\DC2\EOT\206\SOH\ACK\v\n\
+    \\a\EOT\a\EOT\NUL\STX\SOH\SOH\DC2\EOT\217\SOH\ACK\v\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\SOH\STX\DC2\EOT\206\SOH\SO\SI\n\
+    \\a\EOT\a\EOT\NUL\STX\SOH\STX\DC2\EOT\217\SOH\SO\SI\n\
     \\ESC\n\
-    \\ACK\EOT\a\EOT\NUL\STX\STX\DC2\EOT\208\SOH\ACK\DC4\SUB\v For Alloy\n\
+    \\ACK\EOT\a\EOT\NUL\STX\STX\DC2\EOT\219\SOH\ACK\DC4\SUB\v For Alloy\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\STX\SOH\DC2\EOT\208\SOH\ACK\SI\n\
+    \\a\EOT\a\EOT\NUL\STX\STX\SOH\DC2\EOT\219\SOH\ACK\SI\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\STX\STX\DC2\EOT\208\SOH\DC2\DC3\n\
+    \\a\EOT\a\EOT\NUL\STX\STX\STX\DC2\EOT\219\SOH\DC2\DC3\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\ETX\DC2\EOT\209\SOH\ACK\EM\n\
+    \\ACK\EOT\a\EOT\NUL\STX\ETX\DC2\EOT\220\SOH\ACK\EM\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\ETX\SOH\DC2\EOT\209\SOH\ACK\DC4\n\
+    \\a\EOT\a\EOT\NUL\STX\ETX\SOH\DC2\EOT\220\SOH\ACK\DC4\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\ETX\STX\DC2\EOT\209\SOH\ETB\CAN\n\
+    \\a\EOT\a\EOT\NUL\STX\ETX\STX\DC2\EOT\220\SOH\ETB\CAN\n\
     \\EM\n\
-    \\ACK\EOT\a\EOT\NUL\STX\EOT\DC2\EOT\211\SOH\ACK\DC4\SUB\t For C++\n\
+    \\ACK\EOT\a\EOT\NUL\STX\EOT\DC2\EOT\222\SOH\ACK\DC4\SUB\t For C++\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\EOT\SOH\DC2\EOT\211\SOH\ACK\SI\n\
+    \\a\EOT\a\EOT\NUL\STX\EOT\SOH\DC2\EOT\222\SOH\ACK\SI\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\EOT\STX\DC2\EOT\211\SOH\DC2\DC3\n\
+    \\a\EOT\a\EOT\NUL\STX\EOT\STX\DC2\EOT\222\SOH\DC2\DC3\n\
     \\SUB\n\
-    \\ACK\EOT\a\EOT\NUL\STX\ENQ\DC2\EOT\213\SOH\ACK\DLE\SUB\n\
+    \\ACK\EOT\a\EOT\NUL\STX\ENQ\DC2\EOT\224\SOH\ACK\DLE\SUB\n\
     \ For Lean\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\ENQ\SOH\DC2\EOT\213\SOH\ACK\v\n\
+    \\a\EOT\a\EOT\NUL\STX\ENQ\SOH\DC2\EOT\224\SOH\ACK\v\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\ENQ\STX\DC2\EOT\213\SOH\SO\SI\n\
+    \\a\EOT\a\EOT\NUL\STX\ENQ\STX\DC2\EOT\224\SOH\SO\SI\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\ACK\DC2\EOT\214\SOH\ACK\DC2\n\
+    \\ACK\EOT\a\EOT\NUL\STX\ACK\DC2\EOT\225\SOH\ACK\DC2\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\ACK\SOH\DC2\EOT\214\SOH\ACK\r\n\
+    \\a\EOT\a\EOT\NUL\STX\ACK\SOH\DC2\EOT\225\SOH\ACK\r\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\ACK\STX\DC2\EOT\214\SOH\DLE\DC1\n\
+    \\a\EOT\a\EOT\NUL\STX\ACK\STX\DC2\EOT\225\SOH\DLE\DC1\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\a\DC2\EOT\215\SOH\ACK\DLE\n\
+    \\ACK\EOT\a\EOT\NUL\STX\a\DC2\EOT\226\SOH\ACK\DLE\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\a\SOH\DC2\EOT\215\SOH\ACK\v\n\
+    \\a\EOT\a\EOT\NUL\STX\a\SOH\DC2\EOT\226\SOH\ACK\v\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\a\STX\DC2\EOT\215\SOH\SO\SI\n\
+    \\a\EOT\a\EOT\NUL\STX\a\STX\DC2\EOT\226\SOH\SO\SI\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\b\DC2\EOT\216\SOH\ACK\DC3\n\
+    \\ACK\EOT\a\EOT\NUL\STX\b\DC2\EOT\227\SOH\ACK\DC3\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\b\SOH\DC2\EOT\216\SOH\ACK\SO\n\
+    \\a\EOT\a\EOT\NUL\STX\b\SOH\DC2\EOT\227\SOH\ACK\SO\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\b\STX\DC2\EOT\216\SOH\DC1\DC2\n\
+    \\a\EOT\a\EOT\NUL\STX\b\STX\DC2\EOT\227\SOH\DC1\DC2\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\t\DC2\EOT\217\SOH\ACK\SYN\n\
+    \\ACK\EOT\a\EOT\NUL\STX\t\DC2\EOT\228\SOH\ACK\SYN\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\t\SOH\DC2\EOT\217\SOH\ACK\DC1\n\
+    \\a\EOT\a\EOT\NUL\STX\t\SOH\DC2\EOT\228\SOH\ACK\DC1\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\t\STX\DC2\EOT\217\SOH\DC4\NAK\n\
+    \\a\EOT\a\EOT\NUL\STX\t\STX\DC2\EOT\228\SOH\DC4\NAK\n\
     \\GS\n\
     \\ACK\EOT\a\EOT\NUL\STX\n\
-    \\DC2\EOT\219\SOH\ACK\SYN\SUB\r For Haskell\n\
+    \\DC2\EOT\230\SOH\ACK\SYN\SUB\r For Haskell\n\
     \\n\
     \\SI\n\
     \\a\EOT\a\EOT\NUL\STX\n\
-    \\SOH\DC2\EOT\219\SOH\ACK\DLE\n\
+    \\SOH\DC2\EOT\230\SOH\ACK\DLE\n\
     \\SI\n\
     \\a\EOT\a\EOT\NUL\STX\n\
-    \\STX\DC2\EOT\219\SOH\DC3\NAK\n\
+    \\STX\DC2\EOT\230\SOH\DC3\NAK\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\v\DC2\EOT\220\SOH\ACK\DLE\n\
+    \\ACK\EOT\a\EOT\NUL\STX\v\DC2\EOT\231\SOH\ACK\DLE\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\v\SOH\DC2\EOT\220\SOH\ACK\n\
+    \\a\EOT\a\EOT\NUL\STX\v\SOH\DC2\EOT\231\SOH\ACK\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\v\STX\DC2\EOT\220\SOH\r\SI\n\
+    \\a\EOT\a\EOT\NUL\STX\v\STX\DC2\EOT\231\SOH\r\SI\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\f\DC2\EOT\221\SOH\ACK\SYN\n\
+    \\ACK\EOT\a\EOT\NUL\STX\f\DC2\EOT\232\SOH\ACK\SYN\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\f\SOH\DC2\EOT\221\SOH\ACK\DLE\n\
+    \\a\EOT\a\EOT\NUL\STX\f\SOH\DC2\EOT\232\SOH\ACK\DLE\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\f\STX\DC2\EOT\221\SOH\DC3\NAK\n\
+    \\a\EOT\a\EOT\NUL\STX\f\STX\DC2\EOT\232\SOH\DC3\NAK\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\r\DC2\EOT\222\SOH\ACK\DC1\n\
+    \\ACK\EOT\a\EOT\NUL\STX\r\DC2\EOT\233\SOH\ACK\DC1\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\r\SOH\DC2\EOT\222\SOH\ACK\v\n\
+    \\a\EOT\a\EOT\NUL\STX\r\SOH\DC2\EOT\233\SOH\ACK\v\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\r\STX\DC2\EOT\222\SOH\SO\DLE\n\
+    \\a\EOT\a\EOT\NUL\STX\r\STX\DC2\EOT\233\SOH\SO\DLE\n\
     \\ESC\n\
-    \\ACK\EOT\a\EOT\NUL\STX\SO\DC2\EOT\224\SOH\ACK\DLE\SUB\v For Alloy\n\
+    \\ACK\EOT\a\EOT\NUL\STX\SO\DC2\EOT\235\SOH\ACK\DLE\SUB\v For Alloy\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\SO\SOH\DC2\EOT\224\SOH\ACK\n\
+    \\a\EOT\a\EOT\NUL\STX\SO\SOH\DC2\EOT\235\SOH\ACK\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\SO\STX\DC2\EOT\224\SOH\r\SI\n\
+    \\a\EOT\a\EOT\NUL\STX\SO\STX\DC2\EOT\235\SOH\r\SI\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\SI\DC2\EOT\225\SOH\ACK\DC1\n\
+    \\ACK\EOT\a\EOT\NUL\STX\SI\DC2\EOT\236\SOH\ACK\DC1\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\SI\SOH\DC2\EOT\225\SOH\ACK\v\n\
+    \\a\EOT\a\EOT\NUL\STX\SI\SOH\DC2\EOT\236\SOH\ACK\v\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\SI\STX\DC2\EOT\225\SOH\SO\DLE\n\
+    \\a\EOT\a\EOT\NUL\STX\SI\STX\DC2\EOT\236\SOH\SO\DLE\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\DLE\DC2\EOT\226\SOH\ACK\DLE\n\
+    \\ACK\EOT\a\EOT\NUL\STX\DLE\DC2\EOT\237\SOH\ACK\DLE\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\DLE\SOH\DC2\EOT\226\SOH\ACK\n\
+    \\a\EOT\a\EOT\NUL\STX\DLE\SOH\DC2\EOT\237\SOH\ACK\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\DLE\STX\DC2\EOT\226\SOH\r\SI\n\
+    \\a\EOT\a\EOT\NUL\STX\DLE\STX\DC2\EOT\237\SOH\r\SI\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\DC1\DC2\EOT\227\SOH\ACK\DC4\n\
+    \\ACK\EOT\a\EOT\NUL\STX\DC1\DC2\EOT\238\SOH\ACK\DC4\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\DC1\SOH\DC2\EOT\227\SOH\ACK\SO\n\
+    \\a\EOT\a\EOT\NUL\STX\DC1\SOH\DC2\EOT\238\SOH\ACK\SO\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\DC1\STX\DC2\EOT\227\SOH\DC1\DC3\n\
+    \\a\EOT\a\EOT\NUL\STX\DC1\STX\DC2\EOT\238\SOH\DC1\DC3\n\
     \$\n\
-    \\ACK\EOT\a\EOT\NUL\STX\DC2\DC2\EOT\229\SOH\ACK\DC2\SUB\DC4 For 'get' in Swift\n\
+    \\ACK\EOT\a\EOT\NUL\STX\DC2\DC2\EOT\240\SOH\ACK\DC2\SUB\DC4 For 'get' in Swift\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\DC2\SOH\DC2\EOT\229\SOH\ACK\f\n\
+    \\a\EOT\a\EOT\NUL\STX\DC2\SOH\DC2\EOT\240\SOH\ACK\f\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\DC2\STX\DC2\EOT\229\SOH\SI\DC1\n\
+    \\a\EOT\a\EOT\NUL\STX\DC2\STX\DC2\EOT\240\SOH\SI\DC1\n\
     \\SUB\n\
-    \\ACK\EOT\a\EOT\NUL\STX\DC3\DC2\EOT\231\SOH\ACK\DC3\SUB\n\
+    \\ACK\EOT\a\EOT\NUL\STX\DC3\DC2\EOT\242\SOH\ACK\DC3\SUB\n\
     \ For Raku\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\DC3\SOH\DC2\EOT\231\SOH\ACK\r\n\
+    \\a\EOT\a\EOT\NUL\STX\DC3\SOH\DC2\EOT\242\SOH\ACK\r\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\DC3\STX\DC2\EOT\231\SOH\DLE\DC2\n\
+    \\a\EOT\a\EOT\NUL\STX\DC3\STX\DC2\EOT\242\SOH\DLE\DC2\n\
     \)\n\
-    \\ACK\EOT\a\EOT\NUL\STX\DC4\DC2\EOT\233\SOH\ACK\DC4\SUB\EM For Purescript and Lean\n\
+    \\ACK\EOT\a\EOT\NUL\STX\DC4\DC2\EOT\244\SOH\ACK\DC4\SUB\EM For Purescript and Lean\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\DC4\SOH\DC2\EOT\233\SOH\ACK\SO\n\
+    \\a\EOT\a\EOT\NUL\STX\DC4\SOH\DC2\EOT\244\SOH\ACK\SO\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\DC4\STX\DC2\EOT\233\SOH\DC1\DC3\n\
+    \\a\EOT\a\EOT\NUL\STX\DC4\STX\DC2\EOT\244\SOH\DC1\DC3\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\NAK\DC2\EOT\234\SOH\ACK\NAK\n\
+    \\ACK\EOT\a\EOT\NUL\STX\NAK\DC2\EOT\245\SOH\ACK\NAK\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\NAK\SOH\DC2\EOT\234\SOH\ACK\SI\n\
+    \\a\EOT\a\EOT\NUL\STX\NAK\SOH\DC2\EOT\245\SOH\ACK\SI\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\NAK\STX\DC2\EOT\234\SOH\DC2\DC4\n\
+    \\a\EOT\a\EOT\NUL\STX\NAK\STX\DC2\EOT\245\SOH\DC2\DC4\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\SYN\DC2\EOT\235\SOH\ACK\SI\n\
+    \\ACK\EOT\a\EOT\NUL\STX\SYN\DC2\EOT\246\SOH\ACK\SI\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\SYN\SOH\DC2\EOT\235\SOH\ACK\t\n\
+    \\a\EOT\a\EOT\NUL\STX\SYN\SOH\DC2\EOT\246\SOH\ACK\t\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\SYN\STX\DC2\EOT\235\SOH\f\SO\n\
+    \\a\EOT\a\EOT\NUL\STX\SYN\STX\DC2\EOT\246\SOH\f\SO\n\
     \\FS\n\
-    \\ACK\EOT\a\EOT\NUL\STX\ETB\DC2\EOT\237\SOH\ACK\DLE\SUB\f For Racket\n\
+    \\ACK\EOT\a\EOT\NUL\STX\ETB\DC2\EOT\248\SOH\ACK\DLE\SUB\f For Racket\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\ETB\SOH\DC2\EOT\237\SOH\ACK\n\
+    \\a\EOT\a\EOT\NUL\STX\ETB\SOH\DC2\EOT\248\SOH\ACK\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\ETB\STX\DC2\EOT\237\SOH\r\SI\n\
+    \\a\EOT\a\EOT\NUL\STX\ETB\STX\DC2\EOT\248\SOH\r\SI\n\
     \\SUB\n\
-    \\ACK\EOT\a\EOT\NUL\STX\CAN\DC2\EOT\239\SOH\ACK\DC1\SUB\n\
+    \\ACK\EOT\a\EOT\NUL\STX\CAN\DC2\EOT\250\SOH\ACK\DC1\SUB\n\
     \ For Lean\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\CAN\SOH\DC2\EOT\239\SOH\ACK\v\n\
+    \\a\EOT\a\EOT\NUL\STX\CAN\SOH\DC2\EOT\250\SOH\ACK\v\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\CAN\STX\DC2\EOT\239\SOH\SO\DLE\n\
+    \\a\EOT\a\EOT\NUL\STX\CAN\STX\DC2\EOT\250\SOH\SO\DLE\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\EM\DC2\EOT\240\SOH\ACK\DC1\n\
+    \\ACK\EOT\a\EOT\NUL\STX\EM\DC2\EOT\251\SOH\ACK\DC1\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\EM\SOH\DC2\EOT\240\SOH\ACK\v\n\
+    \\a\EOT\a\EOT\NUL\STX\EM\SOH\DC2\EOT\251\SOH\ACK\v\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\EM\STX\DC2\EOT\240\SOH\SO\DLE\n\
+    \\a\EOT\a\EOT\NUL\STX\EM\STX\DC2\EOT\251\SOH\SO\DLE\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\SUB\DC2\EOT\241\SOH\ACK\DC2\n\
+    \\ACK\EOT\a\EOT\NUL\STX\SUB\DC2\EOT\252\SOH\ACK\DC2\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\SUB\SOH\DC2\EOT\241\SOH\ACK\f\n\
+    \\a\EOT\a\EOT\NUL\STX\SUB\SOH\DC2\EOT\252\SOH\ACK\f\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\SUB\STX\DC2\EOT\241\SOH\SI\DC1\n\
+    \\a\EOT\a\EOT\NUL\STX\SUB\STX\DC2\EOT\252\SOH\SI\DC1\n\
     \\148\SOH\n\
-    \\ACK\EOT\a\EOT\NUL\STX\ESC\DC2\EOT\244\SOH\ACK\SUB\SUB\131\SOH Analogous to 'ThisParameter' and 'SelfParameter', but for languages\n\
+    \\ACK\EOT\a\EOT\NUL\STX\ESC\DC2\EOT\255\SOH\ACK\SUB\SUB\131\SOH Analogous to 'ThisParameter' and 'SelfParameter', but for languages\n\
     \ like Go where the receiver doesn't have a conventional name.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\ESC\SOH\DC2\EOT\244\SOH\ACK\DC4\n\
+    \\a\EOT\a\EOT\NUL\STX\ESC\SOH\DC2\EOT\255\SOH\ACK\DC4\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\ESC\STX\DC2\EOT\244\SOH\ETB\EM\n\
+    \\a\EOT\a\EOT\NUL\STX\ESC\STX\DC2\EOT\255\SOH\ETB\EM\n\
     \\RS\n\
-    \\ACK\EOT\a\EOT\NUL\STX\FS\DC2\EOT\246\SOH\ACK\DC3\SUB\SO For Protobuf\n\
+    \\ACK\EOT\a\EOT\NUL\STX\FS\DC2\EOT\129\STX\ACK\DC3\SUB\SO For Protobuf\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\FS\SOH\DC2\EOT\246\SOH\ACK\r\n\
+    \\a\EOT\a\EOT\NUL\STX\FS\SOH\DC2\EOT\129\STX\ACK\r\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\FS\STX\DC2\EOT\246\SOH\DLE\DC2\n\
+    \\a\EOT\a\EOT\NUL\STX\FS\STX\DC2\EOT\129\STX\DLE\DC2\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\GS\DC2\EOT\247\SOH\ACK\DC2\n\
+    \\ACK\EOT\a\EOT\NUL\STX\GS\DC2\EOT\130\STX\ACK\DC2\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\GS\SOH\DC2\EOT\247\SOH\ACK\f\n\
+    \\a\EOT\a\EOT\NUL\STX\GS\SOH\DC2\EOT\130\STX\ACK\f\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\GS\STX\DC2\EOT\247\SOH\SI\DC1\n\
+    \\a\EOT\a\EOT\NUL\STX\GS\STX\DC2\EOT\130\STX\SI\DC1\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\RS\DC2\EOT\248\SOH\ACK\NAK\n\
+    \\ACK\EOT\a\EOT\NUL\STX\RS\DC2\EOT\131\STX\ACK\NAK\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\RS\SOH\DC2\EOT\248\SOH\ACK\SI\n\
+    \\a\EOT\a\EOT\NUL\STX\RS\SOH\DC2\EOT\131\STX\ACK\SI\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\RS\STX\DC2\EOT\248\SOH\DC2\DC4\n\
+    \\a\EOT\a\EOT\NUL\STX\RS\STX\DC2\EOT\131\STX\DC2\DC4\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\US\DC2\EOT\249\SOH\ACK\DLE\n\
+    \\ACK\EOT\a\EOT\NUL\STX\US\DC2\EOT\132\STX\ACK\DLE\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\US\SOH\DC2\EOT\249\SOH\ACK\n\
+    \\a\EOT\a\EOT\NUL\STX\US\SOH\DC2\EOT\132\STX\ACK\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\US\STX\DC2\EOT\249\SOH\r\SI\n\
+    \\a\EOT\a\EOT\NUL\STX\US\STX\DC2\EOT\132\STX\r\SI\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX \DC2\EOT\250\SOH\ACK\DC2\n\
+    \\ACK\EOT\a\EOT\NUL\STX \DC2\EOT\133\STX\ACK\DC2\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX \SOH\DC2\EOT\250\SOH\ACK\f\n\
+    \\a\EOT\a\EOT\NUL\STX \SOH\DC2\EOT\133\STX\ACK\f\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX \STX\DC2\EOT\250\SOH\SI\DC1\n\
+    \\a\EOT\a\EOT\NUL\STX \STX\DC2\EOT\133\STX\SI\DC1\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX!\DC2\EOT\251\SOH\ACK\DC2\n\
+    \\ACK\EOT\a\EOT\NUL\STX!\DC2\EOT\134\STX\ACK\DC2\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX!\SOH\DC2\EOT\251\SOH\ACK\f\n\
+    \\a\EOT\a\EOT\NUL\STX!\SOH\DC2\EOT\134\STX\ACK\f\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX!\STX\DC2\EOT\251\SOH\SI\DC1\n\
+    \\a\EOT\a\EOT\NUL\STX!\STX\DC2\EOT\134\STX\SI\DC1\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX\"\DC2\EOT\252\SOH\ACK\DC4\n\
+    \\ACK\EOT\a\EOT\NUL\STX\"\DC2\EOT\135\STX\ACK\DC4\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\"\SOH\DC2\EOT\252\SOH\ACK\SO\n\
+    \\a\EOT\a\EOT\NUL\STX\"\SOH\DC2\EOT\135\STX\ACK\SO\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX\"\STX\DC2\EOT\252\SOH\DC1\DC3\n\
+    \\a\EOT\a\EOT\NUL\STX\"\STX\DC2\EOT\135\STX\DC1\DC3\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX#\DC2\EOT\253\SOH\ACK\DC3\n\
+    \\ACK\EOT\a\EOT\NUL\STX#\DC2\EOT\136\STX\ACK\DC3\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX#\SOH\DC2\EOT\253\SOH\ACK\r\n\
+    \\a\EOT\a\EOT\NUL\STX#\SOH\DC2\EOT\136\STX\ACK\r\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX#\STX\DC2\EOT\253\SOH\DLE\DC2\n\
+    \\a\EOT\a\EOT\NUL\STX#\STX\DC2\EOT\136\STX\DLE\DC2\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX$\DC2\EOT\254\SOH\ACK\EM\n\
+    \\ACK\EOT\a\EOT\NUL\STX$\DC2\EOT\137\STX\ACK\EM\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX$\SOH\DC2\EOT\254\SOH\ACK\DC3\n\
+    \\a\EOT\a\EOT\NUL\STX$\SOH\DC2\EOT\137\STX\ACK\DC3\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX$\STX\DC2\EOT\254\SOH\SYN\CAN\n\
+    \\a\EOT\a\EOT\NUL\STX$\STX\DC2\EOT\137\STX\SYN\CAN\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX%\DC2\EOT\255\SOH\ACK\NAK\n\
+    \\ACK\EOT\a\EOT\NUL\STX%\DC2\EOT\138\STX\ACK\NAK\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX%\SOH\DC2\EOT\255\SOH\ACK\SI\n\
+    \\a\EOT\a\EOT\NUL\STX%\SOH\DC2\EOT\138\STX\ACK\SI\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX%\STX\DC2\EOT\255\SOH\DC2\DC4\n\
+    \\a\EOT\a\EOT\NUL\STX%\STX\DC2\EOT\138\STX\DC2\DC4\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX&\DC2\EOT\128\STX\ACK\SUB\n\
+    \\ACK\EOT\a\EOT\NUL\STX&\DC2\EOT\139\STX\ACK\SUB\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX&\SOH\DC2\EOT\128\STX\ACK\DC4\n\
+    \\a\EOT\a\EOT\NUL\STX&\SOH\DC2\EOT\139\STX\ACK\DC4\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX&\STX\DC2\EOT\128\STX\ETB\EM\n\
+    \\a\EOT\a\EOT\NUL\STX&\STX\DC2\EOT\139\STX\ETB\EM\n\
     \/\n\
-    \\ACK\EOT\a\EOT\NUL\STX'\DC2\EOT\130\STX\ACK\DC3\SUB\US For Haskell's PatternSynonyms\n\
+    \\ACK\EOT\a\EOT\NUL\STX'\DC2\EOT\141\STX\ACK\DC3\SUB\US For Haskell's PatternSynonyms\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX'\SOH\DC2\EOT\130\STX\ACK\r\n\
+    \\a\EOT\a\EOT\NUL\STX'\SOH\DC2\EOT\141\STX\ACK\r\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX'\STX\DC2\EOT\130\STX\DLE\DC2\n\
+    \\a\EOT\a\EOT\NUL\STX'\STX\DC2\EOT\141\STX\DLE\DC2\n\
     \\ESC\n\
-    \\ACK\EOT\a\EOT\NUL\STX(\DC2\EOT\132\STX\ACK\NAK\SUB\v For Alloy\n\
+    \\ACK\EOT\a\EOT\NUL\STX(\DC2\EOT\143\STX\ACK\NAK\SUB\v For Alloy\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX(\SOH\DC2\EOT\132\STX\ACK\SI\n\
+    \\a\EOT\a\EOT\NUL\STX(\SOH\DC2\EOT\143\STX\ACK\SI\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX(\STX\DC2\EOT\132\STX\DC2\DC4\n\
+    \\a\EOT\a\EOT\NUL\STX(\STX\DC2\EOT\143\STX\DC2\DC4\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX)\DC2\EOT\133\STX\ACK\DC4\n\
+    \\ACK\EOT\a\EOT\NUL\STX)\DC2\EOT\144\STX\ACK\DC4\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX)\SOH\DC2\EOT\133\STX\ACK\SO\n\
+    \\a\EOT\a\EOT\NUL\STX)\SOH\DC2\EOT\144\STX\ACK\SO\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX)\STX\DC2\EOT\133\STX\DC1\DC3\n\
+    \\a\EOT\a\EOT\NUL\STX)\STX\DC2\EOT\144\STX\DC1\DC3\n\
     \Q\n\
-    \\ACK\EOT\a\EOT\NUL\STX*\DC2\EOT\135\STX\ACK\DC4\SUBA Analogous to 'Trait' and 'TypeClass', for Swift and Objective-C\n\
+    \\ACK\EOT\a\EOT\NUL\STX*\DC2\EOT\146\STX\ACK\DC4\SUBA Analogous to 'Trait' and 'TypeClass', for Swift and Objective-C\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX*\SOH\DC2\EOT\135\STX\ACK\SO\n\
+    \\a\EOT\a\EOT\NUL\STX*\SOH\DC2\EOT\146\STX\ACK\SO\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX*\STX\DC2\EOT\135\STX\DC1\DC3\n\
+    \\a\EOT\a\EOT\NUL\STX*\STX\DC2\EOT\146\STX\DC1\DC3\n\
     \\GS\n\
-    \\ACK\EOT\a\EOT\NUL\STX+\DC2\EOT\137\STX\ACK\ETB\SUB\r For Haskell\n\
+    \\ACK\EOT\a\EOT\NUL\STX+\DC2\EOT\148\STX\ACK\ETB\SUB\r For Haskell\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX+\SOH\DC2\EOT\137\STX\ACK\DC1\n\
+    \\a\EOT\a\EOT\NUL\STX+\SOH\DC2\EOT\148\STX\ACK\DC1\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX+\STX\DC2\EOT\137\STX\DC4\SYN\n\
+    \\a\EOT\a\EOT\NUL\STX+\STX\DC2\EOT\148\STX\DC4\SYN\n\
     \4\n\
-    \\ACK\EOT\a\EOT\NUL\STX,\DC2\EOT\139\STX\ACK\EM\SUB$ 'self' in Python, Rust, Swift etc.\n\
+    \\ACK\EOT\a\EOT\NUL\STX,\DC2\EOT\150\STX\ACK\EM\SUB$ 'self' in Python, Rust, Swift etc.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX,\SOH\DC2\EOT\139\STX\ACK\DC3\n\
+    \\a\EOT\a\EOT\NUL\STX,\SOH\DC2\EOT\150\STX\ACK\DC3\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX,\STX\DC2\EOT\139\STX\SYN\CAN\n\
+    \\a\EOT\a\EOT\NUL\STX,\STX\DC2\EOT\150\STX\SYN\CAN\n\
     \$\n\
-    \\ACK\EOT\a\EOT\NUL\STX-\DC2\EOT\141\STX\ACK\DC2\SUB\DC4 For 'set' in Swift\n\
+    \\ACK\EOT\a\EOT\NUL\STX-\DC2\EOT\152\STX\ACK\DC2\SUB\DC4 For 'set' in Swift\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX-\SOH\DC2\EOT\141\STX\ACK\f\n\
+    \\a\EOT\a\EOT\NUL\STX-\SOH\DC2\EOT\152\STX\ACK\f\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX-\STX\DC2\EOT\141\STX\SI\DC1\n\
+    \\a\EOT\a\EOT\NUL\STX-\STX\DC2\EOT\152\STX\SI\DC1\n\
     \3\n\
-    \\ACK\EOT\a\EOT\NUL\STX.\DC2\EOT\143\STX\ACK\NAK\SUB# For Alloy, analogous to 'Struct'.\n\
+    \\ACK\EOT\a\EOT\NUL\STX.\DC2\EOT\154\STX\ACK\NAK\SUB# For Alloy, analogous to 'Struct'.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX.\SOH\DC2\EOT\143\STX\ACK\SI\n\
+    \\a\EOT\a\EOT\NUL\STX.\SOH\DC2\EOT\154\STX\ACK\SI\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX.\STX\DC2\EOT\143\STX\DC2\DC4\n\
+    \\a\EOT\a\EOT\NUL\STX.\STX\DC2\EOT\154\STX\DC2\DC4\n\
     \\ESC\n\
-    \\ACK\EOT\a\EOT\NUL\STX/\DC2\EOT\145\STX\ACK\NAK\SUB\v For Swift\n\
+    \\ACK\EOT\a\EOT\NUL\STX/\DC2\EOT\156\STX\ACK\NAK\SUB\v For Swift\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX/\SOH\DC2\EOT\145\STX\ACK\SI\n\
+    \\a\EOT\a\EOT\NUL\STX/\SOH\DC2\EOT\156\STX\ACK\SI\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX/\STX\DC2\EOT\145\STX\DC2\DC4\n\
+    \\a\EOT\a\EOT\NUL\STX/\STX\DC2\EOT\156\STX\DC2\DC4\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX0\DC2\EOT\146\STX\ACK\DC2\n\
+    \\ACK\EOT\a\EOT\NUL\STX0\DC2\EOT\157\STX\ACK\DC2\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX0\SOH\DC2\EOT\146\STX\ACK\f\n\
+    \\a\EOT\a\EOT\NUL\STX0\SOH\DC2\EOT\157\STX\ACK\f\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX0\STX\DC2\EOT\146\STX\SI\DC1\n\
+    \\a\EOT\a\EOT\NUL\STX0\STX\DC2\EOT\157\STX\SI\DC1\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX1\DC2\EOT\147\STX\ACK\DC2\n\
+    \\ACK\EOT\a\EOT\NUL\STX1\DC2\EOT\158\STX\ACK\DC2\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX1\SOH\DC2\EOT\147\STX\ACK\f\n\
+    \\a\EOT\a\EOT\NUL\STX1\SOH\DC2\EOT\158\STX\ACK\f\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX1\STX\DC2\EOT\147\STX\SI\DC1\n\
+    \\a\EOT\a\EOT\NUL\STX1\STX\DC2\EOT\158\STX\SI\DC1\n\
     \\SUB\n\
-    \\ACK\EOT\a\EOT\NUL\STX2\DC2\EOT\149\STX\ACK\DC2\SUB\n\
+    \\ACK\EOT\a\EOT\NUL\STX2\DC2\EOT\160\STX\ACK\DC2\SUB\n\
     \ For Lean\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX2\SOH\DC2\EOT\149\STX\ACK\f\n\
+    \\a\EOT\a\EOT\NUL\STX2\SOH\DC2\EOT\160\STX\ACK\f\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX2\STX\DC2\EOT\149\STX\SI\DC1\n\
+    \\a\EOT\a\EOT\NUL\STX2\STX\DC2\EOT\160\STX\SI\DC1\n\
     \\SUB\n\
-    \\ACK\EOT\a\EOT\NUL\STX3\DC2\EOT\151\STX\ACK\DC3\SUB\n\
+    \\ACK\EOT\a\EOT\NUL\STX3\DC2\EOT\162\STX\ACK\DC3\SUB\n\
     \ For Lean\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX3\SOH\DC2\EOT\151\STX\ACK\r\n\
+    \\a\EOT\a\EOT\NUL\STX3\SOH\DC2\EOT\162\STX\ACK\r\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX3\STX\DC2\EOT\151\STX\DLE\DC2\n\
+    \\a\EOT\a\EOT\NUL\STX3\STX\DC2\EOT\162\STX\DLE\DC2\n\
     \U\n\
-    \\ACK\EOT\a\EOT\NUL\STX4\DC2\EOT\154\STX\ACK\EM\SUBE Method receiver for languages\n\
+    \\ACK\EOT\a\EOT\NUL\STX4\DC2\EOT\165\STX\ACK\EM\SUBE Method receiver for languages\n\
     \ 'this' in JavaScript, C++, Java etc.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX4\SOH\DC2\EOT\154\STX\ACK\DC3\n\
+    \\a\EOT\a\EOT\NUL\STX4\SOH\DC2\EOT\165\STX\ACK\DC3\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX4\STX\DC2\EOT\154\STX\SYN\CAN\n\
+    \\a\EOT\a\EOT\NUL\STX4\STX\DC2\EOT\165\STX\SYN\CAN\n\
     \D\n\
-    \\ACK\EOT\a\EOT\NUL\STX5\DC2\EOT\156\STX\ACK\DC1\SUB4 Analogous to 'Protocol' and 'TypeClass', for Rust.\n\
+    \\ACK\EOT\a\EOT\NUL\STX5\DC2\EOT\167\STX\ACK\DC1\SUB4 Analogous to 'Protocol' and 'TypeClass', for Rust.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX5\SOH\DC2\EOT\156\STX\ACK\v\n\
+    \\a\EOT\a\EOT\NUL\STX5\SOH\DC2\EOT\167\STX\ACK\v\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX5\STX\DC2\EOT\156\STX\SO\DLE\n\
+    \\a\EOT\a\EOT\NUL\STX5\STX\DC2\EOT\167\STX\SO\DLE\n\
     \\137\SOH\n\
-    \\ACK\EOT\a\EOT\NUL\STX6\DC2\EOT\159\STX\ACK\DLE\SUBy Data type definition for languages like OCaml which use `type`\n\
+    \\ACK\EOT\a\EOT\NUL\STX6\DC2\EOT\170\STX\ACK\DLE\SUBy Data type definition for languages like OCaml which use `type`\n\
     \ rather than separate keywords like `struct` and `enum`.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX6\SOH\DC2\EOT\159\STX\ACK\n\
+    \\a\EOT\a\EOT\NUL\STX6\SOH\DC2\EOT\170\STX\ACK\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX6\STX\DC2\EOT\159\STX\r\SI\n\
+    \\a\EOT\a\EOT\NUL\STX6\STX\DC2\EOT\170\STX\r\SI\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX7\DC2\EOT\160\STX\ACK\NAK\n\
+    \\ACK\EOT\a\EOT\NUL\STX7\DC2\EOT\171\STX\ACK\NAK\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX7\SOH\DC2\EOT\160\STX\ACK\SI\n\
+    \\a\EOT\a\EOT\NUL\STX7\SOH\DC2\EOT\171\STX\ACK\SI\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX7\STX\DC2\EOT\160\STX\DC2\DC4\n\
+    \\a\EOT\a\EOT\NUL\STX7\STX\DC2\EOT\171\STX\DC2\DC4\n\
     \S\n\
-    \\ACK\EOT\a\EOT\NUL\STX8\DC2\EOT\162\STX\ACK\NAK\SUBC Analogous to 'Trait' and 'Protocol', for Haskell, Purescript etc.\n\
+    \\ACK\EOT\a\EOT\NUL\STX8\DC2\EOT\173\STX\ACK\NAK\SUBC Analogous to 'Trait' and 'Protocol', for Haskell, Purescript etc.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX8\SOH\DC2\EOT\162\STX\ACK\SI\n\
+    \\a\EOT\a\EOT\NUL\STX8\SOH\DC2\EOT\173\STX\ACK\SI\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX8\STX\DC2\EOT\162\STX\DC2\DC4\n\
+    \\a\EOT\a\EOT\NUL\STX8\STX\DC2\EOT\173\STX\DC2\DC4\n\
     \\GS\n\
-    \\ACK\EOT\a\EOT\NUL\STX9\DC2\EOT\164\STX\ACK\SYN\SUB\r For Haskell\n\
+    \\ACK\EOT\a\EOT\NUL\STX9\DC2\EOT\175\STX\ACK\SYN\SUB\r For Haskell\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX9\SOH\DC2\EOT\164\STX\ACK\DLE\n\
+    \\a\EOT\a\EOT\NUL\STX9\SOH\DC2\EOT\175\STX\ACK\DLE\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX9\STX\DC2\EOT\164\STX\DC3\NAK\n\
+    \\a\EOT\a\EOT\NUL\STX9\STX\DC2\EOT\175\STX\DC3\NAK\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX:\DC2\EOT\165\STX\ACK\EM\n\
+    \\ACK\EOT\a\EOT\NUL\STX:\DC2\EOT\176\STX\ACK\EM\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX:\SOH\DC2\EOT\165\STX\ACK\DC3\n\
+    \\a\EOT\a\EOT\NUL\STX:\SOH\DC2\EOT\176\STX\ACK\DC3\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX:\STX\DC2\EOT\165\STX\SYN\CAN\n\
+    \\a\EOT\a\EOT\NUL\STX:\STX\DC2\EOT\176\STX\SYN\CAN\n\
     \(\n\
-    \\ACK\EOT\a\EOT\NUL\STX;\DC2\EOT\167\STX\ACK\DC1\SUB\CAN For C, C++, Capn Proto\n\
+    \\ACK\EOT\a\EOT\NUL\STX;\DC2\EOT\178\STX\ACK\DC1\SUB\CAN For C, C++, Capn Proto\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX;\SOH\DC2\EOT\167\STX\ACK\v\n\
+    \\a\EOT\a\EOT\NUL\STX;\SOH\DC2\EOT\178\STX\ACK\v\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX;\STX\DC2\EOT\167\STX\SO\DLE\n\
+    \\a\EOT\a\EOT\NUL\STX;\STX\DC2\EOT\178\STX\SO\DLE\n\
     \\SO\n\
-    \\ACK\EOT\a\EOT\NUL\STX<\DC2\EOT\168\STX\ACK\DC1\n\
+    \\ACK\EOT\a\EOT\NUL\STX<\DC2\EOT\179\STX\ACK\DC1\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX<\SOH\DC2\EOT\168\STX\ACK\v\n\
+    \\a\EOT\a\EOT\NUL\STX<\SOH\DC2\EOT\179\STX\ACK\v\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX<\STX\DC2\EOT\168\STX\SO\DLE\n\
+    \\a\EOT\a\EOT\NUL\STX<\STX\DC2\EOT\179\STX\SO\DLE\n\
     \[\n\
-    \\ACK\EOT\a\EOT\NUL\STX=\DC2\EOT\169\STX\ACK\DC4\"K Next = 62;\n\
+    \\ACK\EOT\a\EOT\NUL\STX=\DC2\EOT\180\STX\ACK\DC4\"K Next = 62;\n\
     \ Feel free to open a PR proposing new language-specific kinds.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX=\SOH\DC2\EOT\169\STX\ACK\SO\n\
+    \\a\EOT\a\EOT\NUL\STX=\SOH\DC2\EOT\180\STX\ACK\SO\n\
     \\SI\n\
-    \\a\EOT\a\EOT\NUL\STX=\STX\DC2\EOT\169\STX\DC1\DC3\n\
+    \\a\EOT\a\EOT\NUL\STX=\STX\DC2\EOT\180\STX\DC1\DC3\n\
+    \\243\ETX\n\
+    \\EOT\EOT\a\STX\EOT\DC2\EOT\193\STX\STX\SUB\SUB\228\ETX (optional) The name of this symbol as it should be displayed to the user.\n\
+    \ For example, the symbol \"com/example/MyClass#myMethod(+1).\" should have the\n\
+    \ display name \"myMethod\". The `symbol` field is not a reliable source of\n\
+    \ the display name for several reasons:\n\
+    \\n\
+    \ - Local symbols don't encode the name.\n\
+    \ - Some languages have case-insensitive names, so the symbol is all-lowercase.\n\
+    \ - The symbol may encode names with special characters that should not be\n\
+    \   displayed to the user.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\EOT\ENQ\DC2\EOT\193\STX\STX\b\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\EOT\SOH\DC2\EOT\193\STX\t\NAK\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\EOT\ETX\DC2\EOT\193\STX\CAN\EM\n\
+    \\196\ETX\n\
+    \\EOT\EOT\a\STX\ENQ\DC2\EOT\200\STX\STX'\SUB\181\ETX (optional) The signature of this symbol as it's displayed in API\n\
+    \ documentation or in hover tooltips. For example, a Java method that adds\n\
+    \ two numbers this would have `Document.language = \"java\"` and `Document.text\n\
+    \ = \"void add(int a, int b)\". The `language` and `text` fields are required\n\
+    \ while other fields such as `Documentation.occurrences` can be optionally\n\
+    \ included to support hyperlinking referenced symbols in the signature.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\ENQ\ACK\DC2\EOT\200\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\ENQ\SOH\DC2\EOT\200\STX\v\"\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\ENQ\ETX\DC2\EOT\200\STX%&\n\
     \\f\n\
-    \\STX\EOT\b\DC2\ACK\176\STX\NUL\232\STX\SOH\n\
+    \\STX\EOT\b\DC2\ACK\204\STX\NUL\132\ETX\SOH\n\
     \\v\n\
-    \\ETX\EOT\b\SOH\DC2\EOT\176\STX\b\DC4\n\
+    \\ETX\EOT\b\SOH\DC2\EOT\204\STX\b\DC4\n\
     \\f\n\
-    \\EOT\EOT\b\STX\NUL\DC2\EOT\177\STX\STX\DC4\n\
+    \\EOT\EOT\b\STX\NUL\DC2\EOT\205\STX\STX\DC4\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\NUL\ENQ\DC2\EOT\177\STX\STX\b\n\
+    \\ENQ\EOT\b\STX\NUL\ENQ\DC2\EOT\205\STX\STX\b\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\NUL\SOH\DC2\EOT\177\STX\t\SI\n\
+    \\ENQ\EOT\b\STX\NUL\SOH\DC2\EOT\205\STX\t\SI\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\NUL\ETX\DC2\EOT\177\STX\DC2\DC3\n\
+    \\ENQ\EOT\b\STX\NUL\ETX\DC2\EOT\205\STX\DC2\DC3\n\
     \\222\b\n\
-    \\EOT\EOT\b\STX\SOH\DC2\EOT\202\STX\STX\CAN\SUB\207\b When resolving \"Find references\", this field documents what other symbols\n\
+    \\EOT\EOT\b\STX\SOH\DC2\EOT\230\STX\STX\CAN\SUB\207\b When resolving \"Find references\", this field documents what other symbols\n\
     \ should be included together with this symbol. For example, consider the\n\
     \ following TypeScript code that defines two symbols `Animal#sound()` and\n\
     \ `Dog#sound()`:\n\
@@ -6760,13 +6976,13 @@ packedFileDescriptor
     \ `Animal#sound()` method as well.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\SOH\ENQ\DC2\EOT\202\STX\STX\ACK\n\
+    \\ENQ\EOT\b\STX\SOH\ENQ\DC2\EOT\230\STX\STX\ACK\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\SOH\SOH\DC2\EOT\202\STX\a\DC3\n\
+    \\ENQ\EOT\b\STX\SOH\SOH\DC2\EOT\230\STX\a\DC3\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\SOH\ETX\DC2\EOT\202\STX\SYN\ETB\n\
+    \\ENQ\EOT\b\STX\SOH\ETX\DC2\EOT\230\STX\SYN\ETB\n\
     \\238\ETX\n\
-    \\EOT\EOT\b\STX\STX\DC2\EOT\211\STX\STX\GS\SUB\223\ETX Similar to `is_reference` but for \"Find implementations\".\n\
+    \\EOT\EOT\b\STX\STX\DC2\EOT\239\STX\STX\GS\SUB\223\ETX Similar to `is_reference` but for \"Find implementations\".\n\
     \ It's common for `is_implementation` and `is_reference` to both be true but\n\
     \ it's not always the case.\n\
     \ In the TypeScript example above, observe that `Dog#` has an\n\
@@ -6776,22 +6992,22 @@ packedFileDescriptor
     \ implementations\" on the \"Animal#\" symbol.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\STX\ENQ\DC2\EOT\211\STX\STX\ACK\n\
+    \\ENQ\EOT\b\STX\STX\ENQ\DC2\EOT\239\STX\STX\ACK\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\STX\SOH\DC2\EOT\211\STX\a\CAN\n\
+    \\ENQ\EOT\b\STX\STX\SOH\DC2\EOT\239\STX\a\CAN\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\STX\ETX\DC2\EOT\211\STX\ESC\FS\n\
+    \\ENQ\EOT\b\STX\STX\ETX\DC2\EOT\239\STX\ESC\FS\n\
     \P\n\
-    \\EOT\EOT\b\STX\ETX\DC2\EOT\213\STX\STX\RS\SUBB Similar to `references_symbols` but for \"Go to type definition\".\n\
+    \\EOT\EOT\b\STX\ETX\DC2\EOT\241\STX\STX\RS\SUBB Similar to `references_symbols` but for \"Go to type definition\".\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\ETX\ENQ\DC2\EOT\213\STX\STX\ACK\n\
+    \\ENQ\EOT\b\STX\ETX\ENQ\DC2\EOT\241\STX\STX\ACK\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\ETX\SOH\DC2\EOT\213\STX\a\EM\n\
+    \\ENQ\EOT\b\STX\ETX\SOH\DC2\EOT\241\STX\a\EM\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\ETX\ETX\DC2\EOT\213\STX\FS\GS\n\
+    \\ENQ\EOT\b\STX\ETX\ETX\DC2\EOT\241\STX\FS\GS\n\
     \\167\a\n\
-    \\EOT\EOT\b\STX\EOT\DC2\EOT\230\STX\STX\EM\SUB\213\ACK Allows overriding the behavior of \"Go to definition\" and \"Find references\"\n\
+    \\EOT\EOT\b\STX\EOT\DC2\EOT\130\ETX\STX\EM\SUB\213\ACK Allows overriding the behavior of \"Go to definition\" and \"Find references\"\n\
     \ for symbols which do not have a definition of their own or could\n\
     \ potentially have multiple definitions.\n\
     \\n\
@@ -6810,376 +7026,376 @@ packedFileDescriptor
     \\"A Update registerInverseRelationships on adding a new field here.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\EOT\ENQ\DC2\EOT\230\STX\STX\ACK\n\
+    \\ENQ\EOT\b\STX\EOT\ENQ\DC2\EOT\130\ETX\STX\ACK\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\EOT\SOH\DC2\EOT\230\STX\a\DC4\n\
+    \\ENQ\EOT\b\STX\EOT\SOH\DC2\EOT\130\ETX\a\DC4\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\EOT\ETX\DC2\EOT\230\STX\ETB\CAN\n\
+    \\ENQ\EOT\b\STX\EOT\ETX\DC2\EOT\130\ETX\ETB\CAN\n\
     \\136\ETX\n\
-    \\STX\ENQ\STX\DC2\ACK\239\STX\NUL\255\STX\SOH\SUB\249\STX SymbolRole declares what \"role\" a symbol has in an occurrence. A role is\n\
+    \\STX\ENQ\STX\DC2\ACK\139\ETX\NUL\155\ETX\SOH\SUB\249\STX SymbolRole declares what \"role\" a symbol has in an occurrence. A role is\n\
     \ encoded as a bitset where each bit represents a different role. For example,\n\
     \ to determine if the `Import` role is set, test whether the second bit of the\n\
     \ enum value is defined. In pseudocode, this can be implemented with the\n\
     \ logic: `const isImportRole = (role.value & SymbolRole.Import.value) > 0`.\n\
     \\n\
     \\v\n\
-    \\ETX\ENQ\STX\SOH\DC2\EOT\239\STX\ENQ\SI\n\
+    \\ETX\ENQ\STX\SOH\DC2\EOT\139\ETX\ENQ\SI\n\
     \v\n\
-    \\EOT\ENQ\STX\STX\NUL\DC2\EOT\242\STX\STX\FS\SUBh This case is not meant to be used; it only exists to avoid an error\n\
+    \\EOT\ENQ\STX\STX\NUL\DC2\EOT\142\ETX\STX\FS\SUBh This case is not meant to be used; it only exists to avoid an error\n\
     \ from the Protobuf code generator.\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\STX\STX\NUL\SOH\DC2\EOT\242\STX\STX\ETB\n\
+    \\ENQ\ENQ\STX\STX\NUL\SOH\DC2\EOT\142\ETX\STX\ETB\n\
     \\r\n\
-    \\ENQ\ENQ\STX\STX\NUL\STX\DC2\EOT\242\STX\SUB\ESC\n\
+    \\ENQ\ENQ\STX\STX\NUL\STX\DC2\EOT\142\ETX\SUB\ESC\n\
     \T\n\
-    \\EOT\ENQ\STX\STX\SOH\DC2\EOT\244\STX\STX\DC3\SUBF Is the symbol defined here? If not, then this is a symbol reference.\n\
+    \\EOT\ENQ\STX\STX\SOH\DC2\EOT\144\ETX\STX\DC3\SUBF Is the symbol defined here? If not, then this is a symbol reference.\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\STX\STX\SOH\SOH\DC2\EOT\244\STX\STX\f\n\
+    \\ENQ\ENQ\STX\STX\SOH\SOH\DC2\EOT\144\ETX\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\STX\STX\SOH\STX\DC2\EOT\244\STX\SI\DC2\n\
+    \\ENQ\ENQ\STX\STX\SOH\STX\DC2\EOT\144\ETX\SI\DC2\n\
     \,\n\
-    \\EOT\ENQ\STX\STX\STX\DC2\EOT\246\STX\STX\SI\SUB\RS Is the symbol imported here?\n\
+    \\EOT\ENQ\STX\STX\STX\DC2\EOT\146\ETX\STX\SI\SUB\RS Is the symbol imported here?\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\STX\STX\STX\SOH\DC2\EOT\246\STX\STX\b\n\
+    \\ENQ\ENQ\STX\STX\STX\SOH\DC2\EOT\146\ETX\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\STX\STX\STX\STX\DC2\EOT\246\STX\v\SO\n\
+    \\ENQ\ENQ\STX\STX\STX\STX\DC2\EOT\146\ETX\v\SO\n\
     \+\n\
-    \\EOT\ENQ\STX\STX\ETX\DC2\EOT\248\STX\STX\DC4\SUB\GS Is the symbol written here?\n\
+    \\EOT\ENQ\STX\STX\ETX\DC2\EOT\148\ETX\STX\DC4\SUB\GS Is the symbol written here?\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\STX\STX\ETX\SOH\DC2\EOT\248\STX\STX\r\n\
+    \\ENQ\ENQ\STX\STX\ETX\SOH\DC2\EOT\148\ETX\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\STX\STX\ETX\STX\DC2\EOT\248\STX\DLE\DC3\n\
+    \\ENQ\ENQ\STX\STX\ETX\STX\DC2\EOT\148\ETX\DLE\DC3\n\
     \(\n\
-    \\EOT\ENQ\STX\STX\EOT\DC2\EOT\250\STX\STX\DC3\SUB\SUB Is the symbol read here?\n\
+    \\EOT\ENQ\STX\STX\EOT\DC2\EOT\150\ETX\STX\DC3\SUB\SUB Is the symbol read here?\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\STX\STX\EOT\SOH\DC2\EOT\250\STX\STX\f\n\
+    \\ENQ\ENQ\STX\STX\EOT\SOH\DC2\EOT\150\ETX\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\STX\STX\EOT\STX\DC2\EOT\250\STX\SI\DC2\n\
+    \\ENQ\ENQ\STX\STX\EOT\STX\DC2\EOT\150\ETX\SI\DC2\n\
     \0\n\
-    \\EOT\ENQ\STX\STX\ENQ\DC2\EOT\252\STX\STX\DC3\SUB\" Is the symbol in generated code?\n\
+    \\EOT\ENQ\STX\STX\ENQ\DC2\EOT\152\ETX\STX\DC3\SUB\" Is the symbol in generated code?\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\STX\STX\ENQ\SOH\DC2\EOT\252\STX\STX\v\n\
+    \\ENQ\ENQ\STX\STX\ENQ\SOH\DC2\EOT\152\ETX\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\STX\STX\ENQ\STX\DC2\EOT\252\STX\SO\DC2\n\
+    \\ENQ\ENQ\STX\STX\ENQ\STX\DC2\EOT\152\ETX\SO\DC2\n\
     \+\n\
-    \\EOT\ENQ\STX\STX\ACK\DC2\EOT\254\STX\STX\SO\SUB\GS Is the symbol in test code?\n\
+    \\EOT\ENQ\STX\STX\ACK\DC2\EOT\154\ETX\STX\SO\SUB\GS Is the symbol in test code?\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\STX\STX\ACK\SOH\DC2\EOT\254\STX\STX\ACK\n\
+    \\ENQ\ENQ\STX\STX\ACK\SOH\DC2\EOT\154\ETX\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\STX\STX\ACK\STX\DC2\EOT\254\STX\t\r\n\
+    \\ENQ\ENQ\STX\STX\ACK\STX\DC2\EOT\154\ETX\t\r\n\
     \\f\n\
-    \\STX\ENQ\ETX\DC2\ACK\129\ETX\NUL\222\ETX\SOH\n\
+    \\STX\ENQ\ETX\DC2\ACK\157\ETX\NUL\250\ETX\SOH\n\
     \\v\n\
-    \\ETX\ENQ\ETX\SOH\DC2\EOT\129\ETX\ENQ\SI\n\
+    \\ETX\ENQ\ETX\SOH\DC2\EOT\157\ETX\ENQ\SI\n\
     \\v\n\
-    \\ETX\ENQ\ETX\ETX\DC2\EOT\130\ETX\STX\FS\n\
+    \\ETX\ENQ\ETX\ETX\DC2\EOT\158\ETX\STX\FS\n\
     \\f\n\
-    \\EOT\ENQ\ETX\ETX\STX\DC2\EOT\130\ETX\STX\FS\n\
+    \\EOT\ENQ\ETX\ETX\STX\DC2\EOT\158\ETX\STX\FS\n\
     \\f\n\
-    \\EOT\ENQ\ETX\STX\NUL\DC2\EOT\132\ETX\STX\FS\n\
+    \\EOT\ENQ\ETX\STX\NUL\DC2\EOT\160\ETX\STX\FS\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\NUL\SOH\DC2\EOT\132\ETX\STX\ETB\n\
+    \\ENQ\ENQ\ETX\STX\NUL\SOH\DC2\EOT\160\ETX\STX\ETB\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\NUL\STX\DC2\EOT\132\ETX\SUB\ESC\n\
+    \\ENQ\ENQ\ETX\STX\NUL\STX\DC2\EOT\160\ETX\SUB\ESC\n\
     \;\n\
-    \\EOT\ENQ\ETX\STX\SOH\DC2\EOT\135\ETX\STX\SO\SUB- Comment, including comment markers and text\n\
+    \\EOT\ENQ\ETX\STX\SOH\DC2\EOT\163\ETX\STX\SO\SUB- Comment, including comment markers and text\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\SOH\SOH\DC2\EOT\135\ETX\STX\t\n\
+    \\ENQ\ENQ\ETX\STX\SOH\SOH\DC2\EOT\163\ETX\STX\t\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\SOH\STX\DC2\EOT\135\ETX\f\r\n\
+    \\ENQ\ENQ\ETX\STX\SOH\STX\DC2\EOT\163\ETX\f\r\n\
     \\ESC\n\
-    \\EOT\ENQ\ETX\STX\STX\DC2\EOT\138\ETX\STX\ESC\SUB\r `;` `.` `,`\n\
+    \\EOT\ENQ\ETX\STX\STX\DC2\EOT\166\ETX\STX\ESC\SUB\r `;` `.` `,`\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\STX\SOH\DC2\EOT\138\ETX\STX\SYN\n\
+    \\ENQ\ENQ\ETX\STX\STX\SOH\DC2\EOT\166\ETX\STX\SYN\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\STX\STX\DC2\EOT\138\ETX\EM\SUB\n\
+    \\ENQ\ENQ\ETX\STX\STX\STX\DC2\EOT\166\ETX\EM\SUB\n\
     \2\n\
-    \\EOT\ENQ\ETX\STX\ETX\DC2\EOT\140\ETX\STX\EM\SUB$ (), {}, [] when used syntactically\n\
+    \\EOT\ENQ\ETX\STX\ETX\DC2\EOT\168\ETX\STX\EM\SUB$ (), {}, [] when used syntactically\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\ETX\SOH\DC2\EOT\140\ETX\STX\DC4\n\
+    \\ENQ\ENQ\ETX\STX\ETX\SOH\DC2\EOT\168\ETX\STX\DC4\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\ETX\STX\DC2\EOT\140\ETX\ETB\CAN\n\
+    \\ENQ\ENQ\ETX\STX\ETX\STX\DC2\EOT\168\ETX\ETB\CAN\n\
     \5\n\
-    \\EOT\ENQ\ETX\STX\EOT\DC2\EOT\143\ETX\STX\SO\SUB' `if`, `else`, `return`, `class`, etc.\n\
+    \\EOT\ENQ\ETX\STX\EOT\DC2\EOT\171\ETX\STX\SO\SUB' `if`, `else`, `return`, `class`, etc.\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\EOT\SOH\DC2\EOT\143\ETX\STX\t\n\
+    \\ENQ\ENQ\ETX\STX\EOT\SOH\DC2\EOT\171\ETX\STX\t\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\EOT\STX\DC2\EOT\143\ETX\f\r\n\
+    \\ENQ\ENQ\ETX\STX\EOT\STX\DC2\EOT\171\ETX\f\r\n\
     \\f\n\
-    \\EOT\ENQ\ETX\STX\ENQ\DC2\EOT\144\ETX\STX*\n\
+    \\EOT\ENQ\ETX\STX\ENQ\DC2\EOT\172\ETX\STX*\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\ENQ\SOH\DC2\EOT\144\ETX\STX\DC3\n\
+    \\ENQ\ENQ\ETX\STX\ENQ\SOH\DC2\EOT\172\ETX\STX\DC3\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\ENQ\STX\DC2\EOT\144\ETX\SYN\ETB\n\
+    \\ENQ\ENQ\ETX\STX\ENQ\STX\DC2\EOT\172\ETX\SYN\ETB\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\ENQ\ETX\DC2\EOT\144\ETX\CAN)\n\
+    \\ENQ\ENQ\ETX\STX\ENQ\ETX\DC2\EOT\172\ETX\CAN)\n\
     \\SO\n\
-    \\ACK\ENQ\ETX\STX\ENQ\ETX\SOH\DC2\EOT\144\ETX\EM(\n\
+    \\ACK\ENQ\ETX\STX\ENQ\ETX\SOH\DC2\EOT\172\ETX\EM(\n\
     \\RS\n\
-    \\EOT\ENQ\ETX\STX\ACK\DC2\EOT\147\ETX\STX\EM\SUB\DLE `+`, `*`, etc.\n\
+    \\EOT\ENQ\ETX\STX\ACK\DC2\EOT\175\ETX\STX\EM\SUB\DLE `+`, `*`, etc.\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\ACK\SOH\DC2\EOT\147\ETX\STX\DC4\n\
+    \\ENQ\ENQ\ETX\STX\ACK\SOH\DC2\EOT\175\ETX\STX\DC4\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\ACK\STX\DC2\EOT\147\ETX\ETB\CAN\n\
+    \\ENQ\ENQ\ETX\STX\ACK\STX\DC2\EOT\175\ETX\ETB\CAN\n\
     \X\n\
-    \\EOT\ENQ\ETX\STX\a\DC2\EOT\150\ETX\STX\DC1\SUBJ non-specific catch-all for any identifier not better described elsewhere\n\
+    \\EOT\ENQ\ETX\STX\a\DC2\EOT\178\ETX\STX\DC1\SUBJ non-specific catch-all for any identifier not better described elsewhere\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\a\SOH\DC2\EOT\150\ETX\STX\f\n\
+    \\ENQ\ENQ\ETX\STX\a\SOH\DC2\EOT\178\ETX\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\a\STX\DC2\EOT\150\ETX\SI\DLE\n\
+    \\ENQ\ENQ\ETX\STX\a\STX\DC2\EOT\178\ETX\SI\DLE\n\
     \N\n\
-    \\EOT\ENQ\ETX\STX\b\DC2\EOT\152\ETX\STX\CAN\SUB@ Identifiers builtin to the language: `min`, `print` in Python.\n\
+    \\EOT\ENQ\ETX\STX\b\DC2\EOT\180\ETX\STX\CAN\SUB@ Identifiers builtin to the language: `min`, `print` in Python.\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\b\SOH\DC2\EOT\152\ETX\STX\DC3\n\
+    \\ENQ\ENQ\ETX\STX\b\SOH\DC2\EOT\180\ETX\STX\DC3\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\b\STX\DC2\EOT\152\ETX\SYN\ETB\n\
+    \\ENQ\ENQ\ETX\STX\b\STX\DC2\EOT\180\ETX\SYN\ETB\n\
     \[\n\
-    \\EOT\ENQ\ETX\STX\t\DC2\EOT\154\ETX\STX\NAK\SUBM Identifiers representing `null`-like values: `None` in Python, `nil` in Go.\n\
+    \\EOT\ENQ\ETX\STX\t\DC2\EOT\182\ETX\STX\NAK\SUBM Identifiers representing `null`-like values: `None` in Python, `nil` in Go.\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\t\SOH\DC2\EOT\154\ETX\STX\DLE\n\
+    \\ENQ\ENQ\ETX\STX\t\SOH\DC2\EOT\182\ETX\STX\DLE\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\t\STX\DC2\EOT\154\ETX\DC3\DC4\n\
+    \\ENQ\ENQ\ETX\STX\t\STX\DC2\EOT\182\ETX\DC3\DC4\n\
     \.\n\
     \\EOT\ENQ\ETX\STX\n\
-    \\DC2\EOT\156\ETX\STX\EM\SUB  `xyz` in `const xyz = \"hello\"`\n\
+    \\DC2\EOT\184\ETX\STX\EM\SUB  `xyz` in `const xyz = \"hello\"`\n\
     \\n\
     \\r\n\
     \\ENQ\ENQ\ETX\STX\n\
-    \\SOH\DC2\EOT\156\ETX\STX\DC4\n\
+    \\SOH\DC2\EOT\184\ETX\STX\DC4\n\
     \\r\n\
     \\ENQ\ENQ\ETX\STX\n\
-    \\STX\DC2\EOT\156\ETX\ETB\CAN\n\
+    \\STX\DC2\EOT\184\ETX\ETB\CAN\n\
     \'\n\
-    \\EOT\ENQ\ETX\STX\v\DC2\EOT\158\ETX\STX\US\SUB\EM `var X = \"hello\"` in Go\n\
+    \\EOT\ENQ\ETX\STX\v\DC2\EOT\186\ETX\STX\US\SUB\EM `var X = \"hello\"` in Go\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\v\SOH\DC2\EOT\158\ETX\STX\EM\n\
+    \\ENQ\ENQ\ETX\STX\v\SOH\DC2\EOT\186\ETX\STX\EM\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\v\STX\DC2\EOT\158\ETX\FS\RS\n\
+    \\ENQ\ENQ\ETX\STX\v\STX\DC2\EOT\186\ETX\FS\RS\n\
     \3\n\
-    \\EOT\ENQ\ETX\STX\f\DC2\EOT\160\ETX\STX\ESC\SUB% Parameter definition and references\n\
+    \\EOT\ENQ\ETX\STX\f\DC2\EOT\188\ETX\STX\ESC\SUB% Parameter definition and references\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\f\SOH\DC2\EOT\160\ETX\STX\NAK\n\
+    \\ENQ\ENQ\ETX\STX\f\SOH\DC2\EOT\188\ETX\STX\NAK\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\f\STX\DC2\EOT\160\ETX\CAN\SUB\n\
+    \\ENQ\ENQ\ETX\STX\f\STX\DC2\EOT\188\ETX\CAN\SUB\n\
     \X\n\
-    \\EOT\ENQ\ETX\STX\r\DC2\EOT\162\ETX\STX\ETB\SUBJ Identifiers for variable definitions and references within a local scope\n\
+    \\EOT\ENQ\ETX\STX\r\DC2\EOT\190\ETX\STX\ETB\SUBJ Identifiers for variable definitions and references within a local scope\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\r\SOH\DC2\EOT\162\ETX\STX\DC1\n\
+    \\ENQ\ENQ\ETX\STX\r\SOH\DC2\EOT\190\ETX\STX\DC1\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\r\STX\DC2\EOT\162\ETX\DC4\SYN\n\
+    \\ENQ\ENQ\ETX\STX\r\STX\DC2\EOT\190\ETX\DC4\SYN\n\
     \K\n\
-    \\EOT\ENQ\ETX\STX\SO\DC2\EOT\164\ETX\STX\SUB\SUB= Identifiers that shadow other identifiers in an outer scope\n\
+    \\EOT\ENQ\ETX\STX\SO\DC2\EOT\192\ETX\STX\SUB\SUB= Identifiers that shadow other identifiers in an outer scope\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\SO\SOH\DC2\EOT\164\ETX\STX\DC4\n\
+    \\ENQ\ENQ\ETX\STX\SO\SOH\DC2\EOT\192\ETX\STX\DC4\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\SO\STX\DC2\EOT\164\ETX\ETB\EM\n\
+    \\ENQ\ENQ\ETX\STX\SO\STX\DC2\EOT\192\ETX\ETB\EM\n\
     \\205\SOH\n\
-    \\EOT\ENQ\ETX\STX\SI\DC2\EOT\169\ETX\STX\ESC\SUB\190\SOH Identifier representing a unit of code abstraction and/or namespacing.\n\
+    \\EOT\ENQ\ETX\STX\SI\DC2\EOT\197\ETX\STX\ESC\SUB\190\SOH Identifier representing a unit of code abstraction and/or namespacing.\n\
     \\n\
     \ NOTE: This corresponds to a package in Go and JVM languages,\n\
     \ and a module in languages like Python and JavaScript.\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\SI\SOH\DC2\EOT\169\ETX\STX\NAK\n\
+    \\ENQ\ENQ\ETX\STX\SI\SOH\DC2\EOT\197\ETX\STX\NAK\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\SI\STX\DC2\EOT\169\ETX\CAN\SUB\n\
+    \\ENQ\ENQ\ETX\STX\SI\STX\DC2\EOT\197\ETX\CAN\SUB\n\
     \\f\n\
-    \\EOT\ENQ\ETX\STX\DLE\DC2\EOT\170\ETX\STX*\n\
+    \\EOT\ENQ\ETX\STX\DLE\DC2\EOT\198\ETX\STX*\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\DLE\SOH\DC2\EOT\170\ETX\STX\DC2\n\
+    \\ENQ\ENQ\ETX\STX\DLE\SOH\DC2\EOT\198\ETX\STX\DC2\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\DLE\STX\DC2\EOT\170\ETX\NAK\ETB\n\
+    \\ENQ\ENQ\ETX\STX\DLE\STX\DC2\EOT\198\ETX\NAK\ETB\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\DLE\ETX\DC2\EOT\170\ETX\CAN)\n\
+    \\ENQ\ENQ\ETX\STX\DLE\ETX\DC2\EOT\198\ETX\CAN)\n\
     \\SO\n\
-    \\ACK\ENQ\ETX\STX\DLE\ETX\SOH\DC2\EOT\170\ETX\EM(\n\
+    \\ACK\ENQ\ETX\STX\DLE\ETX\SOH\DC2\EOT\198\ETX\EM(\n\
     \4\n\
-    \\EOT\ENQ\ETX\STX\DC1\DC2\EOT\173\ETX\STX\SUB\SUB& Function references, including calls\n\
+    \\EOT\ENQ\ETX\STX\DC1\DC2\EOT\201\ETX\STX\SUB\SUB& Function references, including calls\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\DC1\SOH\DC2\EOT\173\ETX\STX\DC4\n\
+    \\ENQ\ENQ\ETX\STX\DC1\SOH\DC2\EOT\201\ETX\STX\DC4\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\DC1\STX\DC2\EOT\173\ETX\ETB\EM\n\
+    \\ENQ\ENQ\ETX\STX\DC1\STX\DC2\EOT\201\ETX\ETB\EM\n\
     \(\n\
-    \\EOT\ENQ\ETX\STX\DC2\DC2\EOT\175\ETX\STX$\SUB\SUB Function definition only\n\
+    \\EOT\ENQ\ETX\STX\DC2\DC2\EOT\203\ETX\STX$\SUB\SUB Function definition only\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\DC2\SOH\DC2\EOT\175\ETX\STX\RS\n\
+    \\ENQ\ENQ\ETX\STX\DC2\SOH\DC2\EOT\203\ETX\STX\RS\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\DC2\STX\DC2\EOT\175\ETX!#\n\
+    \\ENQ\ENQ\ETX\STX\DC2\STX\DC2\EOT\203\ETX!#\n\
     \7\n\
-    \\EOT\ENQ\ETX\STX\DC3\DC2\EOT\178\ETX\STX\ETB\SUB) Macro references, including invocations\n\
+    \\EOT\ENQ\ETX\STX\DC3\DC2\EOT\206\ETX\STX\ETB\SUB) Macro references, including invocations\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\DC3\SOH\DC2\EOT\178\ETX\STX\DC1\n\
+    \\ENQ\ENQ\ETX\STX\DC3\SOH\DC2\EOT\206\ETX\STX\DC1\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\DC3\STX\DC2\EOT\178\ETX\DC4\SYN\n\
+    \\ENQ\ENQ\ETX\STX\DC3\STX\DC2\EOT\206\ETX\DC4\SYN\n\
     \%\n\
-    \\EOT\ENQ\ETX\STX\DC4\DC2\EOT\180\ETX\STX!\SUB\ETB Macro definition only\n\
+    \\EOT\ENQ\ETX\STX\DC4\DC2\EOT\208\ETX\STX!\SUB\ETB Macro definition only\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\DC4\SOH\DC2\EOT\180\ETX\STX\ESC\n\
+    \\ENQ\ENQ\ETX\STX\DC4\SOH\DC2\EOT\208\ETX\STX\ESC\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\DC4\STX\DC2\EOT\180\ETX\RS \n\
+    \\ENQ\ENQ\ETX\STX\DC4\STX\DC2\EOT\208\ETX\RS \n\
     \!\n\
-    \\EOT\ENQ\ETX\STX\NAK\DC2\EOT\183\ETX\STX\SYN\SUB\DC3 non-builtin types\n\
+    \\EOT\ENQ\ETX\STX\NAK\DC2\EOT\211\ETX\STX\SYN\SUB\DC3 non-builtin types\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\NAK\SOH\DC2\EOT\183\ETX\STX\DLE\n\
+    \\ENQ\ENQ\ETX\STX\NAK\SOH\DC2\EOT\211\ETX\STX\DLE\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\NAK\STX\DC2\EOT\183\ETX\DC3\NAK\n\
+    \\ENQ\ENQ\ETX\STX\NAK\STX\DC2\EOT\211\ETX\DC3\NAK\n\
     \K\n\
-    \\EOT\ENQ\ETX\STX\SYN\DC2\EOT\185\ETX\STX\GS\SUB= builtin types only, such as `str` for Python or `int` in Go\n\
+    \\EOT\ENQ\ETX\STX\SYN\DC2\EOT\213\ETX\STX\GS\SUB= builtin types only, such as `str` for Python or `int` in Go\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\SYN\SOH\DC2\EOT\185\ETX\STX\ETB\n\
+    \\ENQ\ENQ\ETX\STX\SYN\SOH\DC2\EOT\213\ETX\STX\ETB\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\SYN\STX\DC2\EOT\185\ETX\SUB\FS\n\
+    \\ENQ\ENQ\ETX\STX\SYN\STX\DC2\EOT\213\ETX\SUB\FS\n\
     \7\n\
-    \\EOT\ENQ\ETX\STX\ETB\DC2\EOT\188\ETX\STX\ESC\SUB) Python decorators, c-like __attribute__\n\
+    \\EOT\ENQ\ETX\STX\ETB\DC2\EOT\216\ETX\STX\ESC\SUB) Python decorators, c-like __attribute__\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\ETB\SOH\DC2\EOT\188\ETX\STX\NAK\n\
+    \\ENQ\ENQ\ETX\STX\ETB\SOH\DC2\EOT\216\ETX\STX\NAK\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\ETB\STX\DC2\EOT\188\ETX\CAN\SUB\n\
+    \\ENQ\ENQ\ETX\STX\ETB\STX\DC2\EOT\216\ETX\CAN\SUB\n\
     \\DC4\n\
-    \\EOT\ENQ\ETX\STX\CAN\DC2\EOT\191\ETX\STX\DC3\SUB\ACK `\\b`\n\
+    \\EOT\ENQ\ETX\STX\CAN\DC2\EOT\219\ETX\STX\DC3\SUB\ACK `\\b`\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\CAN\SOH\DC2\EOT\191\ETX\STX\r\n\
+    \\ENQ\ENQ\ETX\STX\CAN\SOH\DC2\EOT\219\ETX\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\CAN\STX\DC2\EOT\191\ETX\DLE\DC2\n\
+    \\ENQ\ENQ\ETX\STX\CAN\STX\DC2\EOT\219\ETX\DLE\DC2\n\
     \\CAN\n\
-    \\EOT\ENQ\ETX\STX\EM\DC2\EOT\193\ETX\STX\NAK\SUB\n\
+    \\EOT\ENQ\ETX\STX\EM\DC2\EOT\221\ETX\STX\NAK\SUB\n\
     \ `*`, `+`\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\EM\SOH\DC2\EOT\193\ETX\STX\SI\n\
+    \\ENQ\ENQ\ETX\STX\EM\SOH\DC2\EOT\221\ETX\STX\SI\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\EM\STX\DC2\EOT\193\ETX\DC2\DC4\n\
+    \\ENQ\ENQ\ETX\STX\EM\STX\DC2\EOT\221\ETX\DC2\DC4\n\
     \\DC3\n\
-    \\EOT\ENQ\ETX\STX\SUB\DC2\EOT\195\ETX\STX\NAK\SUB\ENQ `.`\n\
+    \\EOT\ENQ\ETX\STX\SUB\DC2\EOT\223\ETX\STX\NAK\SUB\ENQ `.`\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\SUB\SOH\DC2\EOT\195\ETX\STX\SI\n\
+    \\ENQ\ENQ\ETX\STX\SUB\SOH\DC2\EOT\223\ETX\STX\SI\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\SUB\STX\DC2\EOT\195\ETX\DC2\DC4\n\
+    \\ENQ\ENQ\ETX\STX\SUB\STX\DC2\EOT\223\ETX\DC2\DC4\n\
     \\"\n\
-    \\EOT\ENQ\ETX\STX\ESC\DC2\EOT\197\ETX\STX\SYN\SUB\DC4 `(`, `)`, `[`, `]`\n\
+    \\EOT\ENQ\ETX\STX\ESC\DC2\EOT\225\ETX\STX\SYN\SUB\DC4 `(`, `)`, `[`, `]`\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\ESC\SOH\DC2\EOT\197\ETX\STX\DLE\n\
+    \\ENQ\ENQ\ETX\STX\ESC\SOH\DC2\EOT\225\ETX\STX\DLE\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\ESC\STX\DC2\EOT\197\ETX\DC3\NAK\n\
+    \\ENQ\ENQ\ETX\STX\ESC\STX\DC2\EOT\225\ETX\DC3\NAK\n\
     \\CAN\n\
-    \\EOT\ENQ\ETX\STX\FS\DC2\EOT\199\ETX\STX\DC1\SUB\n\
+    \\EOT\ENQ\ETX\STX\FS\DC2\EOT\227\ETX\STX\DC1\SUB\n\
     \ `|`, `-`\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\FS\SOH\DC2\EOT\199\ETX\STX\v\n\
+    \\ENQ\ENQ\ETX\STX\FS\SOH\DC2\EOT\227\ETX\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\FS\STX\DC2\EOT\199\ETX\SO\DLE\n\
+    \\ENQ\ENQ\ETX\STX\FS\STX\DC2\EOT\227\ETX\SO\DLE\n\
     \0\n\
-    \\EOT\ENQ\ETX\STX\GS\DC2\EOT\202\ETX\STX\NAK\SUB\" Literal strings: \"Hello, world!\"\n\
+    \\EOT\ENQ\ETX\STX\GS\DC2\EOT\230\ETX\STX\NAK\SUB\" Literal strings: \"Hello, world!\"\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\GS\SOH\DC2\EOT\202\ETX\STX\SI\n\
+    \\ENQ\ENQ\ETX\STX\GS\SOH\DC2\EOT\230\ETX\STX\SI\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\GS\STX\DC2\EOT\202\ETX\DC2\DC4\n\
+    \\ENQ\ENQ\ETX\STX\GS\STX\DC2\EOT\230\ETX\DC2\DC4\n\
     \-\n\
-    \\EOT\ENQ\ETX\STX\RS\DC2\EOT\204\ETX\STX\ESC\SUB\US non-regex escapes: \"\\t\", \"\\n\"\n\
+    \\EOT\ENQ\ETX\STX\RS\DC2\EOT\232\ETX\STX\ESC\SUB\US non-regex escapes: \"\\t\", \"\\n\"\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\RS\SOH\DC2\EOT\204\ETX\STX\NAK\n\
+    \\ENQ\ENQ\ETX\STX\RS\SOH\DC2\EOT\232\ETX\STX\NAK\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\RS\STX\DC2\EOT\204\ETX\CAN\SUB\n\
+    \\ENQ\ENQ\ETX\STX\RS\STX\DC2\EOT\232\ETX\CAN\SUB\n\
     \_\n\
-    \\EOT\ENQ\ETX\STX\US\DC2\EOT\206\ETX\STX\FS\SUBQ datetimes within strings, special words within a string, `{}` in format strings\n\
+    \\EOT\ENQ\ETX\STX\US\DC2\EOT\234\ETX\STX\FS\SUBQ datetimes within strings, special words within a string, `{}` in format strings\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\US\SOH\DC2\EOT\206\ETX\STX\SYN\n\
+    \\ENQ\ENQ\ETX\STX\US\SOH\DC2\EOT\234\ETX\STX\SYN\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\US\STX\DC2\EOT\206\ETX\EM\ESC\n\
+    \\ENQ\ENQ\ETX\STX\US\STX\DC2\EOT\234\ETX\EM\ESC\n\
     \G\n\
-    \\EOT\ENQ\ETX\STX \DC2\EOT\208\ETX\STX\CAN\SUB9 \"key\" in { \"key\": \"value\" }, useful for example in JSON\n\
+    \\EOT\ENQ\ETX\STX \DC2\EOT\236\ETX\STX\CAN\SUB9 \"key\" in { \"key\": \"value\" }, useful for example in JSON\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX \SOH\DC2\EOT\208\ETX\STX\DC2\n\
+    \\ENQ\ENQ\ETX\STX \SOH\DC2\EOT\236\ETX\STX\DC2\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX \STX\DC2\EOT\208\ETX\NAK\ETB\n\
+    \\ENQ\ENQ\ETX\STX \STX\DC2\EOT\236\ETX\NAK\ETB\n\
     \V\n\
-    \\EOT\ENQ\ETX\STX!\DC2\EOT\210\ETX\STX\CAN\SUBH 'c' or similar, in languages that differentiate strings and characters\n\
+    \\EOT\ENQ\ETX\STX!\DC2\EOT\238\ETX\STX\CAN\SUBH 'c' or similar, in languages that differentiate strings and characters\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX!\SOH\DC2\EOT\210\ETX\STX\DC2\n\
+    \\ENQ\ENQ\ETX\STX!\SOH\DC2\EOT\238\ETX\STX\DC2\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX!\STX\DC2\EOT\210\ETX\NAK\ETB\n\
+    \\ENQ\ENQ\ETX\STX!\STX\DC2\EOT\238\ETX\NAK\ETB\n\
     \9\n\
-    \\EOT\ENQ\ETX\STX\"\DC2\EOT\212\ETX\STX\SYN\SUB+ Literal numbers, both floats and integers\n\
+    \\EOT\ENQ\ETX\STX\"\DC2\EOT\240\ETX\STX\SYN\SUB+ Literal numbers, both floats and integers\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\"\SOH\DC2\EOT\212\ETX\STX\DLE\n\
+    \\ENQ\ENQ\ETX\STX\"\SOH\DC2\EOT\240\ETX\STX\DLE\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX\"\STX\DC2\EOT\212\ETX\DC3\NAK\n\
+    \\ENQ\ENQ\ETX\STX\"\STX\DC2\EOT\240\ETX\DC3\NAK\n\
     \\US\n\
-    \\EOT\ENQ\ETX\STX#\DC2\EOT\214\ETX\STX\SYN\SUB\DC1 `true`, `false`\n\
+    \\EOT\ENQ\ETX\STX#\DC2\EOT\242\ETX\STX\SYN\SUB\DC1 `true`, `false`\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX#\SOH\DC2\EOT\214\ETX\STX\DLE\n\
+    \\ENQ\ENQ\ETX\STX#\SOH\DC2\EOT\242\ETX\STX\DLE\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX#\STX\DC2\EOT\214\ETX\DC3\NAK\n\
+    \\ENQ\ENQ\ETX\STX#\STX\DC2\EOT\242\ETX\DC3\NAK\n\
     \&\n\
-    \\EOT\ENQ\ETX\STX$\DC2\EOT\217\ETX\STX\v\SUB\CAN Used for XML-like tags\n\
+    \\EOT\ENQ\ETX\STX$\DC2\EOT\245\ETX\STX\v\SUB\CAN Used for XML-like tags\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX$\SOH\DC2\EOT\217\ETX\STX\ENQ\n\
+    \\ENQ\ENQ\ETX\STX$\SOH\DC2\EOT\245\ETX\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX$\STX\DC2\EOT\217\ETX\b\n\
+    \\ENQ\ENQ\ETX\STX$\STX\DC2\EOT\245\ETX\b\n\
     \\n\
     \/\n\
-    \\EOT\ENQ\ETX\STX%\DC2\EOT\219\ETX\STX\DC4\SUB! Attribute name in XML-like tags\n\
+    \\EOT\ENQ\ETX\STX%\DC2\EOT\247\ETX\STX\DC4\SUB! Attribute name in XML-like tags\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX%\SOH\DC2\EOT\219\ETX\STX\SO\n\
+    \\ENQ\ENQ\ETX\STX%\SOH\DC2\EOT\247\ETX\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX%\STX\DC2\EOT\219\ETX\DC1\DC3\n\
+    \\ENQ\ENQ\ETX\STX%\STX\DC2\EOT\247\ETX\DC1\DC3\n\
     \,\n\
-    \\EOT\ENQ\ETX\STX&\DC2\EOT\221\ETX\STX\DC4\SUB\RS Delimiters for XML-like tags\n\
+    \\EOT\ENQ\ETX\STX&\DC2\EOT\249\ETX\STX\DC4\SUB\RS Delimiters for XML-like tags\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX&\SOH\DC2\EOT\221\ETX\STX\SO\n\
+    \\ENQ\ENQ\ETX\STX&\SOH\DC2\EOT\249\ETX\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ETX\STX&\STX\DC2\EOT\221\ETX\DC1\DC3\n\
+    \\ENQ\ENQ\ETX\STX&\STX\DC2\EOT\249\ETX\DC1\DC3\n\
     \\249\SOH\n\
-    \\STX\EOT\t\DC2\ACK\229\ETX\NUL\180\EOT\SOH\SUB\234\SOH Occurrence associates a source position with a symbol and/or highlighting\n\
+    \\STX\EOT\t\DC2\ACK\129\EOT\NUL\208\EOT\SOH\SUB\234\SOH Occurrence associates a source position with a symbol and/or highlighting\n\
     \ information.\n\
     \\n\
     \ If possible, indexers should try to bundle logically related information\n\
     \ across occurrences into a single occurrence to reduce payload sizes.\n\
     \\n\
     \\v\n\
-    \\ETX\EOT\t\SOH\DC2\EOT\229\ETX\b\DC2\n\
+    \\ETX\EOT\t\SOH\DC2\EOT\129\EOT\b\DC2\n\
     \\198\a\n\
-    \\EOT\EOT\t\STX\NUL\DC2\EOT\248\ETX\STX\ESC\SUB\183\a Source position of this occurrence. Must be exactly three or four\n\
+    \\EOT\EOT\t\STX\NUL\DC2\EOT\148\EOT\STX\ESC\SUB\183\a Source position of this occurrence. Must be exactly three or four\n\
     \ elements:\n\
     \\n\
     \ - Four elements: `[startLine, startCharacter, endLine, endCharacter]`\n\
@@ -7199,36 +7415,36 @@ packedFileDescriptor
     \ improvements make up for it.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\NUL\EOT\DC2\EOT\248\ETX\STX\n\
+    \\ENQ\EOT\t\STX\NUL\EOT\DC2\EOT\148\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\NUL\ENQ\DC2\EOT\248\ETX\v\DLE\n\
+    \\ENQ\EOT\t\STX\NUL\ENQ\DC2\EOT\148\EOT\v\DLE\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\NUL\SOH\DC2\EOT\248\ETX\DC1\SYN\n\
+    \\ENQ\EOT\t\STX\NUL\SOH\DC2\EOT\148\EOT\DC1\SYN\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\NUL\ETX\DC2\EOT\248\ETX\EM\SUB\n\
+    \\ENQ\EOT\t\STX\NUL\ETX\DC2\EOT\148\EOT\EM\SUB\n\
     \\138\SOH\n\
-    \\EOT\EOT\t\STX\SOH\DC2\EOT\251\ETX\STX\DC4\SUB| (optional) The symbol that appears at this position. See\n\
+    \\EOT\EOT\t\STX\SOH\DC2\EOT\151\EOT\STX\DC4\SUB| (optional) The symbol that appears at this position. See\n\
     \ `SymbolInformation.symbol` for how to format symbols as strings.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\SOH\ENQ\DC2\EOT\251\ETX\STX\b\n\
+    \\ENQ\EOT\t\STX\SOH\ENQ\DC2\EOT\151\EOT\STX\b\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\SOH\SOH\DC2\EOT\251\ETX\t\SI\n\
+    \\ENQ\EOT\t\STX\SOH\SOH\DC2\EOT\151\EOT\t\SI\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\SOH\ETX\DC2\EOT\251\ETX\DC2\DC3\n\
+    \\ENQ\EOT\t\STX\SOH\ETX\DC2\EOT\151\EOT\DC2\DC3\n\
     \\151\SOH\n\
-    \\EOT\EOT\t\STX\STX\DC2\EOT\254\ETX\STX\EM\SUB\136\SOH (optional) Bitset containing `SymbolRole`s in this occurrence.\n\
+    \\EOT\EOT\t\STX\STX\DC2\EOT\154\EOT\STX\EM\SUB\136\SOH (optional) Bitset containing `SymbolRole`s in this occurrence.\n\
     \ See `SymbolRole`'s documentation for how to read and write this field.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\STX\ENQ\DC2\EOT\254\ETX\STX\a\n\
+    \\ENQ\EOT\t\STX\STX\ENQ\DC2\EOT\154\EOT\STX\a\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\STX\SOH\DC2\EOT\254\ETX\b\DC4\n\
+    \\ENQ\EOT\t\STX\STX\SOH\DC2\EOT\154\EOT\b\DC4\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\STX\ETX\DC2\EOT\254\ETX\ETB\CAN\n\
+    \\ENQ\EOT\t\STX\STX\ETX\DC2\EOT\154\EOT\ETB\CAN\n\
     \\241\ETX\n\
-    \\EOT\EOT\t\STX\ETX\DC2\EOT\135\EOT\STX-\SUB\226\ETX (optional) CommonMark-formatted documentation for this specific range. If\n\
+    \\EOT\EOT\t\STX\ETX\DC2\EOT\163\EOT\STX-\SUB\226\ETX (optional) CommonMark-formatted documentation for this specific range. If\n\
     \ empty, the `Symbol.documentation` field is used instead. One example\n\
     \ where this field might be useful is when the symbol represents a generic\n\
     \ function (with abstract type parameters such as `List<T>`) and at this\n\
@@ -7238,37 +7454,37 @@ packedFileDescriptor
     \ which commonly allow for type-changing assignment.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ETX\EOT\DC2\EOT\135\EOT\STX\n\
+    \\ENQ\EOT\t\STX\ETX\EOT\DC2\EOT\163\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ETX\ENQ\DC2\EOT\135\EOT\v\DC1\n\
+    \\ENQ\EOT\t\STX\ETX\ENQ\DC2\EOT\163\EOT\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ETX\SOH\DC2\EOT\135\EOT\DC2(\n\
+    \\ENQ\EOT\t\STX\ETX\SOH\DC2\EOT\163\EOT\DC2(\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ETX\ETX\DC2\EOT\135\EOT+,\n\
+    \\ENQ\EOT\t\STX\ETX\ETX\DC2\EOT\163\EOT+,\n\
     \X\n\
-    \\EOT\EOT\t\STX\EOT\DC2\EOT\137\EOT\STX\GS\SUBJ (optional) What syntax highlighting class should be used for this range?\n\
+    \\EOT\EOT\t\STX\EOT\DC2\EOT\165\EOT\STX\GS\SUBJ (optional) What syntax highlighting class should be used for this range?\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\EOT\ACK\DC2\EOT\137\EOT\STX\f\n\
+    \\ENQ\EOT\t\STX\EOT\ACK\DC2\EOT\165\EOT\STX\f\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\EOT\SOH\DC2\EOT\137\EOT\r\CAN\n\
+    \\ENQ\EOT\t\STX\EOT\SOH\DC2\EOT\165\EOT\r\CAN\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\EOT\ETX\DC2\EOT\137\EOT\ESC\FS\n\
+    \\ENQ\EOT\t\STX\EOT\ETX\DC2\EOT\165\EOT\ESC\FS\n\
     \W\n\
-    \\EOT\EOT\t\STX\ENQ\DC2\EOT\139\EOT\STX&\SUBI (optional) Diagnostics that have been reported for this specific range.\n\
+    \\EOT\EOT\t\STX\ENQ\DC2\EOT\167\EOT\STX&\SUBI (optional) Diagnostics that have been reported for this specific range.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ENQ\EOT\DC2\EOT\139\EOT\STX\n\
+    \\ENQ\EOT\t\STX\ENQ\EOT\DC2\EOT\167\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ENQ\ACK\DC2\EOT\139\EOT\v\NAK\n\
+    \\ENQ\EOT\t\STX\ENQ\ACK\DC2\EOT\167\EOT\v\NAK\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ENQ\SOH\DC2\EOT\139\EOT\SYN!\n\
+    \\ENQ\EOT\t\STX\ENQ\SOH\DC2\EOT\167\EOT\SYN!\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ENQ\ETX\DC2\EOT\139\EOT$%\n\
+    \\ENQ\EOT\t\STX\ENQ\ETX\DC2\EOT\167\EOT$%\n\
     \\128\f\n\
-    \\EOT\EOT\t\STX\ACK\DC2\EOT\179\EOT\STX%\SUB\241\v (optional) Using the same encoding as the sibling `range` field, source\n\
+    \\EOT\EOT\t\STX\ACK\DC2\EOT\207\EOT\STX%\SUB\241\v (optional) Using the same encoding as the sibling `range` field, source\n\
     \ position of the nearest non-trivial enclosing AST node. This range must\n\
     \ enclose the `range` field. Example applications that make use of the\n\
     \ enclosing_range field:\n\
@@ -7309,152 +7525,152 @@ packedFileDescriptor
     \ ```\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ACK\EOT\DC2\EOT\179\EOT\STX\n\
+    \\ENQ\EOT\t\STX\ACK\EOT\DC2\EOT\207\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ACK\ENQ\DC2\EOT\179\EOT\v\DLE\n\
+    \\ENQ\EOT\t\STX\ACK\ENQ\DC2\EOT\207\EOT\v\DLE\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ACK\SOH\DC2\EOT\179\EOT\DC1 \n\
+    \\ENQ\EOT\t\STX\ACK\SOH\DC2\EOT\207\EOT\DC1 \n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ACK\ETX\DC2\EOT\179\EOT#$\n\
+    \\ENQ\EOT\t\STX\ACK\ETX\DC2\EOT\207\EOT#$\n\
     \w\n\
     \\STX\EOT\n\
-    \\DC2\ACK\184\EOT\NUL\195\EOT\SOH\SUBi Represents a diagnostic, such as a compiler error or warning, which should be\n\
+    \\DC2\ACK\212\EOT\NUL\223\EOT\SOH\SUBi Represents a diagnostic, such as a compiler error or warning, which should be\n\
     \ reported for a document.\n\
     \\n\
     \\v\n\
     \\ETX\EOT\n\
-    \\SOH\DC2\EOT\184\EOT\b\DC2\n\
+    \\SOH\DC2\EOT\212\EOT\b\DC2\n\
     \W\n\
     \\EOT\EOT\n\
-    \\STX\NUL\DC2\EOT\186\EOT\STX\CAN\SUBI Should this diagnostic be reported as an error, warning, info, or hint?\n\
+    \\STX\NUL\DC2\EOT\214\EOT\STX\CAN\SUBI Should this diagnostic be reported as an error, warning, info, or hint?\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\NUL\ACK\DC2\EOT\186\EOT\STX\n\
+    \\STX\NUL\ACK\DC2\EOT\214\EOT\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\NUL\SOH\DC2\EOT\186\EOT\v\DC3\n\
+    \\STX\NUL\SOH\DC2\EOT\214\EOT\v\DC3\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\NUL\ETX\DC2\EOT\186\EOT\SYN\ETB\n\
+    \\STX\NUL\ETX\DC2\EOT\214\EOT\SYN\ETB\n\
     \]\n\
     \\EOT\EOT\n\
-    \\STX\SOH\DC2\EOT\188\EOT\STX\DC2\SUBO (optional) Code of this diagnostic, which might appear in the user interface.\n\
+    \\STX\SOH\DC2\EOT\216\EOT\STX\DC2\SUBO (optional) Code of this diagnostic, which might appear in the user interface.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SOH\ENQ\DC2\EOT\188\EOT\STX\b\n\
+    \\STX\SOH\ENQ\DC2\EOT\216\EOT\STX\b\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SOH\SOH\DC2\EOT\188\EOT\t\r\n\
+    \\STX\SOH\SOH\DC2\EOT\216\EOT\t\r\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SOH\ETX\DC2\EOT\188\EOT\DLE\DC1\n\
+    \\STX\SOH\ETX\DC2\EOT\216\EOT\DLE\DC1\n\
     \+\n\
     \\EOT\EOT\n\
-    \\STX\STX\DC2\EOT\190\EOT\STX\NAK\SUB\GS Message of this diagnostic.\n\
+    \\STX\STX\DC2\EOT\218\EOT\STX\NAK\SUB\GS Message of this diagnostic.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\STX\ENQ\DC2\EOT\190\EOT\STX\b\n\
+    \\STX\STX\ENQ\DC2\EOT\218\EOT\STX\b\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\STX\SOH\DC2\EOT\190\EOT\t\DLE\n\
+    \\STX\STX\SOH\DC2\EOT\218\EOT\t\DLE\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\STX\ETX\DC2\EOT\190\EOT\DC3\DC4\n\
+    \\STX\STX\ETX\DC2\EOT\218\EOT\DC3\DC4\n\
     \~\n\
     \\EOT\EOT\n\
-    \\STX\ETX\DC2\EOT\193\EOT\STX\DC4\SUBp (optional) Human-readable string describing the source of this diagnostic, e.g.\n\
+    \\STX\ETX\DC2\EOT\221\EOT\STX\DC4\SUBp (optional) Human-readable string describing the source of this diagnostic, e.g.\n\
     \ 'typescript' or 'super lint'.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ETX\ENQ\DC2\EOT\193\EOT\STX\b\n\
+    \\STX\ETX\ENQ\DC2\EOT\221\EOT\STX\b\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ETX\SOH\DC2\EOT\193\EOT\t\SI\n\
+    \\STX\ETX\SOH\DC2\EOT\221\EOT\t\SI\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ETX\ETX\DC2\EOT\193\EOT\DC2\DC3\n\
+    \\STX\ETX\ETX\DC2\EOT\221\EOT\DC2\DC3\n\
     \\f\n\
     \\EOT\EOT\n\
-    \\STX\EOT\DC2\EOT\194\EOT\STX\"\n\
+    \\STX\EOT\DC2\EOT\222\EOT\STX\"\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\EOT\EOT\DC2\EOT\194\EOT\STX\n\
+    \\STX\EOT\EOT\DC2\EOT\222\EOT\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\EOT\ACK\DC2\EOT\194\EOT\v\CAN\n\
+    \\STX\EOT\ACK\DC2\EOT\222\EOT\v\CAN\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\EOT\SOH\DC2\EOT\194\EOT\EM\GS\n\
+    \\STX\EOT\SOH\DC2\EOT\222\EOT\EM\GS\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\EOT\ETX\DC2\EOT\194\EOT !\n\
+    \\STX\EOT\ETX\DC2\EOT\222\EOT !\n\
     \\f\n\
-    \\STX\ENQ\EOT\DC2\ACK\197\EOT\NUL\203\EOT\SOH\n\
+    \\STX\ENQ\EOT\DC2\ACK\225\EOT\NUL\231\EOT\SOH\n\
     \\v\n\
-    \\ETX\ENQ\EOT\SOH\DC2\EOT\197\EOT\ENQ\r\n\
+    \\ETX\ENQ\EOT\SOH\DC2\EOT\225\EOT\ENQ\r\n\
     \\f\n\
-    \\EOT\ENQ\EOT\STX\NUL\DC2\EOT\198\EOT\STX\SUB\n\
+    \\EOT\ENQ\EOT\STX\NUL\DC2\EOT\226\EOT\STX\SUB\n\
     \\r\n\
-    \\ENQ\ENQ\EOT\STX\NUL\SOH\DC2\EOT\198\EOT\STX\NAK\n\
+    \\ENQ\ENQ\EOT\STX\NUL\SOH\DC2\EOT\226\EOT\STX\NAK\n\
     \\r\n\
-    \\ENQ\ENQ\EOT\STX\NUL\STX\DC2\EOT\198\EOT\CAN\EM\n\
+    \\ENQ\ENQ\EOT\STX\NUL\STX\DC2\EOT\226\EOT\CAN\EM\n\
     \\f\n\
-    \\EOT\ENQ\EOT\STX\SOH\DC2\EOT\199\EOT\STX\f\n\
+    \\EOT\ENQ\EOT\STX\SOH\DC2\EOT\227\EOT\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\EOT\STX\SOH\SOH\DC2\EOT\199\EOT\STX\a\n\
+    \\ENQ\ENQ\EOT\STX\SOH\SOH\DC2\EOT\227\EOT\STX\a\n\
     \\r\n\
-    \\ENQ\ENQ\EOT\STX\SOH\STX\DC2\EOT\199\EOT\n\
+    \\ENQ\ENQ\EOT\STX\SOH\STX\DC2\EOT\227\EOT\n\
     \\v\n\
     \\f\n\
-    \\EOT\ENQ\EOT\STX\STX\DC2\EOT\200\EOT\STX\SO\n\
+    \\EOT\ENQ\EOT\STX\STX\DC2\EOT\228\EOT\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\EOT\STX\STX\SOH\DC2\EOT\200\EOT\STX\t\n\
+    \\ENQ\ENQ\EOT\STX\STX\SOH\DC2\EOT\228\EOT\STX\t\n\
     \\r\n\
-    \\ENQ\ENQ\EOT\STX\STX\STX\DC2\EOT\200\EOT\f\r\n\
+    \\ENQ\ENQ\EOT\STX\STX\STX\DC2\EOT\228\EOT\f\r\n\
     \\f\n\
-    \\EOT\ENQ\EOT\STX\ETX\DC2\EOT\201\EOT\STX\DC2\n\
+    \\EOT\ENQ\EOT\STX\ETX\DC2\EOT\229\EOT\STX\DC2\n\
     \\r\n\
-    \\ENQ\ENQ\EOT\STX\ETX\SOH\DC2\EOT\201\EOT\STX\r\n\
+    \\ENQ\ENQ\EOT\STX\ETX\SOH\DC2\EOT\229\EOT\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\EOT\STX\ETX\STX\DC2\EOT\201\EOT\DLE\DC1\n\
+    \\ENQ\ENQ\EOT\STX\ETX\STX\DC2\EOT\229\EOT\DLE\DC1\n\
     \\f\n\
-    \\EOT\ENQ\EOT\STX\EOT\DC2\EOT\202\EOT\STX\v\n\
+    \\EOT\ENQ\EOT\STX\EOT\DC2\EOT\230\EOT\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\EOT\STX\EOT\SOH\DC2\EOT\202\EOT\STX\ACK\n\
+    \\ENQ\ENQ\EOT\STX\EOT\SOH\DC2\EOT\230\EOT\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\EOT\STX\EOT\STX\DC2\EOT\202\EOT\t\n\
+    \\ENQ\ENQ\EOT\STX\EOT\STX\DC2\EOT\230\EOT\t\n\
     \\n\
     \\f\n\
-    \\STX\ENQ\ENQ\DC2\ACK\205\EOT\NUL\209\EOT\SOH\n\
+    \\STX\ENQ\ENQ\DC2\ACK\233\EOT\NUL\237\EOT\SOH\n\
     \\v\n\
-    \\ETX\ENQ\ENQ\SOH\DC2\EOT\205\EOT\ENQ\DC2\n\
+    \\ETX\ENQ\ENQ\SOH\DC2\EOT\233\EOT\ENQ\DC2\n\
     \\f\n\
-    \\EOT\ENQ\ENQ\STX\NUL\DC2\EOT\206\EOT\STX\US\n\
+    \\EOT\ENQ\ENQ\STX\NUL\DC2\EOT\234\EOT\STX\US\n\
     \\r\n\
-    \\ENQ\ENQ\ENQ\STX\NUL\SOH\DC2\EOT\206\EOT\STX\SUB\n\
+    \\ENQ\ENQ\ENQ\STX\NUL\SOH\DC2\EOT\234\EOT\STX\SUB\n\
     \\r\n\
-    \\ENQ\ENQ\ENQ\STX\NUL\STX\DC2\EOT\206\EOT\GS\RS\n\
+    \\ENQ\ENQ\ENQ\STX\NUL\STX\DC2\EOT\234\EOT\GS\RS\n\
     \\f\n\
-    \\EOT\ENQ\ENQ\STX\SOH\DC2\EOT\207\EOT\STX\DC2\n\
+    \\EOT\ENQ\ENQ\STX\SOH\DC2\EOT\235\EOT\STX\DC2\n\
     \\r\n\
-    \\ENQ\ENQ\ENQ\STX\SOH\SOH\DC2\EOT\207\EOT\STX\r\n\
+    \\ENQ\ENQ\ENQ\STX\SOH\SOH\DC2\EOT\235\EOT\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\ENQ\STX\SOH\STX\DC2\EOT\207\EOT\DLE\DC1\n\
+    \\ENQ\ENQ\ENQ\STX\SOH\STX\DC2\EOT\235\EOT\DLE\DC1\n\
     \\f\n\
-    \\EOT\ENQ\ENQ\STX\STX\DC2\EOT\208\EOT\STX\DC1\n\
+    \\EOT\ENQ\ENQ\STX\STX\DC2\EOT\236\EOT\STX\DC1\n\
     \\r\n\
-    \\ENQ\ENQ\ENQ\STX\STX\SOH\DC2\EOT\208\EOT\STX\f\n\
+    \\ENQ\ENQ\ENQ\STX\STX\SOH\DC2\EOT\236\EOT\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ENQ\STX\STX\STX\DC2\EOT\208\EOT\SI\DLE\n\
+    \\ENQ\ENQ\ENQ\STX\STX\STX\DC2\EOT\236\EOT\SI\DLE\n\
     \\214\ETX\n\
-    \\STX\ENQ\ACK\DC2\ACK\217\EOT\NUL\191\ENQ\SOH\SUB\199\ETX Language standardises names of common programming languages that can be used\n\
+    \\STX\ENQ\ACK\DC2\ACK\245\EOT\NUL\219\ENQ\SOH\SUB\199\ETX Language standardises names of common programming languages that can be used\n\
     \ for the `Document.language` field. The primary purpose of this enum is to\n\
     \ prevent a situation where we have a single programming language ends up with\n\
     \ multiple string representations. For example, the C++ language uses the name\n\
@@ -7462,605 +7678,605 @@ packedFileDescriptor
     \ Feel free to send a pull-request to add missing programming languages.\n\
     \\n\
     \\v\n\
-    \\ETX\ENQ\ACK\SOH\DC2\EOT\217\EOT\ENQ\r\n\
+    \\ETX\ENQ\ACK\SOH\DC2\EOT\245\EOT\ENQ\r\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\NUL\DC2\EOT\218\EOT\STX\SUB\n\
+    \\EOT\ENQ\ACK\STX\NUL\DC2\EOT\246\EOT\STX\SUB\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\NUL\SOH\DC2\EOT\218\EOT\STX\NAK\n\
+    \\ENQ\ENQ\ACK\STX\NUL\SOH\DC2\EOT\246\EOT\STX\NAK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\NUL\STX\DC2\EOT\218\EOT\CAN\EM\n\
+    \\ENQ\ENQ\ACK\STX\NUL\STX\DC2\EOT\246\EOT\CAN\EM\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\SOH\DC2\EOT\219\EOT\STX\f\n\
+    \\EOT\ENQ\ACK\STX\SOH\DC2\EOT\247\EOT\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\SOH\SOH\DC2\EOT\219\EOT\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STX\SOH\SOH\DC2\EOT\247\EOT\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\SOH\STX\DC2\EOT\219\EOT\t\v\n\
+    \\ENQ\ENQ\ACK\STX\SOH\STX\DC2\EOT\247\EOT\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\STX\DC2\EOT\220\EOT\STX\v\n\
+    \\EOT\ENQ\ACK\STX\STX\DC2\EOT\248\EOT\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\STX\SOH\DC2\EOT\220\EOT\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STX\STX\SOH\DC2\EOT\248\EOT\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\STX\STX\DC2\EOT\220\EOT\b\n\
+    \\ENQ\ENQ\ACK\STX\STX\STX\DC2\EOT\248\EOT\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\ETX\DC2\EOT\221\EOT\STX\v\n\
+    \\EOT\ENQ\ACK\STX\ETX\DC2\EOT\249\EOT\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\ETX\SOH\DC2\EOT\221\EOT\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STX\ETX\SOH\DC2\EOT\249\EOT\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\ETX\STX\DC2\EOT\221\EOT\b\n\
+    \\ENQ\ENQ\ACK\STX\ETX\STX\DC2\EOT\249\EOT\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\EOT\DC2\EOT\222\EOT\STX\f\n\
+    \\EOT\ENQ\ACK\STX\EOT\DC2\EOT\250\EOT\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\EOT\SOH\DC2\EOT\222\EOT\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STX\EOT\SOH\DC2\EOT\250\EOT\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\EOT\STX\DC2\EOT\222\EOT\t\v\n\
+    \\ENQ\ENQ\ACK\STX\EOT\STX\DC2\EOT\250\EOT\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\ENQ\DC2\EOT\223\EOT\STX\DLE\n\
+    \\EOT\ENQ\ACK\STX\ENQ\DC2\EOT\251\EOT\STX\DLE\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\ENQ\SOH\DC2\EOT\223\EOT\STX\n\
+    \\ENQ\ENQ\ACK\STX\ENQ\SOH\DC2\EOT\251\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\ENQ\STX\DC2\EOT\223\EOT\r\SI\n\
+    \\ENQ\ENQ\ACK\STX\ENQ\STX\DC2\EOT\251\EOT\r\SI\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\ACK\DC2\EOT\224\EOT\STX\DLE\n\
+    \\EOT\ENQ\ACK\STX\ACK\DC2\EOT\252\EOT\STX\DLE\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\ACK\SOH\DC2\EOT\224\EOT\STX\n\
+    \\ENQ\ENQ\ACK\STX\ACK\SOH\DC2\EOT\252\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\ACK\STX\DC2\EOT\224\EOT\r\SI\n\
+    \\ENQ\ENQ\ACK\STX\ACK\STX\DC2\EOT\252\EOT\r\SI\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\a\DC2\EOT\225\EOT\STX\v\n\
+    \\EOT\ENQ\ACK\STX\a\DC2\EOT\253\EOT\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\a\SOH\DC2\EOT\225\EOT\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STX\a\SOH\DC2\EOT\253\EOT\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\a\STX\DC2\EOT\225\EOT\b\n\
+    \\ENQ\ENQ\ACK\STX\a\STX\DC2\EOT\253\EOT\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\b\DC2\EOT\226\EOT\STX\v\n\
+    \\EOT\ENQ\ACK\STX\b\DC2\EOT\254\EOT\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\b\SOH\DC2\EOT\226\EOT\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STX\b\SOH\DC2\EOT\254\EOT\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\b\STX\DC2\EOT\226\EOT\b\n\
+    \\ENQ\ENQ\ACK\STX\b\STX\DC2\EOT\254\EOT\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\t\DC2\EOT\227\EOT\STX\SO\n\
+    \\EOT\ENQ\ACK\STX\t\DC2\EOT\255\EOT\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\t\SOH\DC2\EOT\227\EOT\STX\b\n\
+    \\ENQ\ENQ\ACK\STX\t\SOH\DC2\EOT\255\EOT\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\t\STX\DC2\EOT\227\EOT\v\r\n\
+    \\ENQ\ENQ\ACK\STX\t\STX\DC2\EOT\255\EOT\v\r\n\
     \\f\n\
     \\EOT\ENQ\ACK\STX\n\
-    \\DC2\EOT\228\EOT\STX\t\n\
+    \\DC2\EOT\128\ENQ\STX\t\n\
     \\r\n\
     \\ENQ\ENQ\ACK\STX\n\
-    \\SOH\DC2\EOT\228\EOT\STX\ETX\n\
+    \\SOH\DC2\EOT\128\ENQ\STX\ETX\n\
     \\r\n\
     \\ENQ\ENQ\ACK\STX\n\
-    \\STX\DC2\EOT\228\EOT\ACK\b\n\
+    \\STX\DC2\EOT\128\ENQ\ACK\b\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\v\DC2\EOT\229\EOT\STX\r\n\
+    \\EOT\ENQ\ACK\STX\v\DC2\EOT\129\ENQ\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\v\SOH\DC2\EOT\229\EOT\STX\a\n\
+    \\ENQ\ENQ\ACK\STX\v\SOH\DC2\EOT\129\ENQ\STX\a\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\v\STX\DC2\EOT\229\EOT\n\
+    \\ENQ\ENQ\ACK\STX\v\STX\DC2\EOT\129\ENQ\n\
     \\f\n\
     \H\n\
-    \\EOT\ENQ\ACK\STX\f\DC2\EOT\230\EOT\STX\v\": C++ (the name \"CPP\" was chosen for consistency with LSP)\n\
+    \\EOT\ENQ\ACK\STX\f\DC2\EOT\130\ENQ\STX\v\": C++ (the name \"CPP\" was chosen for consistency with LSP)\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\f\SOH\DC2\EOT\230\EOT\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STX\f\SOH\DC2\EOT\130\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\f\STX\DC2\EOT\230\EOT\b\n\
+    \\ENQ\ENQ\ACK\STX\f\STX\DC2\EOT\130\ENQ\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\r\DC2\EOT\231\EOT\STX\v\n\
+    \\EOT\ENQ\ACK\STX\r\DC2\EOT\131\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\r\SOH\DC2\EOT\231\EOT\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STX\r\SOH\DC2\EOT\131\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\r\STX\DC2\EOT\231\EOT\b\n\
+    \\ENQ\ENQ\ACK\STX\r\STX\DC2\EOT\131\ENQ\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\SO\DC2\EOT\232\EOT\STX\r\n\
+    \\EOT\ENQ\ACK\STX\SO\DC2\EOT\132\ENQ\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\SO\SOH\DC2\EOT\232\EOT\STX\b\n\
+    \\ENQ\ENQ\ACK\STX\SO\SOH\DC2\EOT\132\ENQ\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\SO\STX\DC2\EOT\232\EOT\v\f\n\
+    \\ENQ\ENQ\ACK\STX\SO\STX\DC2\EOT\132\ENQ\v\f\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\SI\DC2\EOT\233\EOT\STX\SO\n\
+    \\EOT\ENQ\ACK\STX\SI\DC2\EOT\133\ENQ\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\SI\SOH\DC2\EOT\233\EOT\STX\t\n\
+    \\ENQ\ENQ\ACK\STX\SI\SOH\DC2\EOT\133\ENQ\STX\t\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\SI\STX\DC2\EOT\233\EOT\f\r\n\
+    \\ENQ\ENQ\ACK\STX\SI\STX\DC2\EOT\133\ENQ\f\r\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\DLE\DC2\EOT\234\EOT\STX\DC4\n\
+    \\EOT\ENQ\ACK\STX\DLE\DC2\EOT\134\ENQ\STX\DC4\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\DLE\SOH\DC2\EOT\234\EOT\STX\SO\n\
+    \\ENQ\ENQ\ACK\STX\DLE\SOH\DC2\EOT\134\ENQ\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\DLE\STX\DC2\EOT\234\EOT\DC1\DC3\n\
+    \\ENQ\ENQ\ACK\STX\DLE\STX\DC2\EOT\134\ENQ\DC1\DC3\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\DC1\DC2\EOT\235\EOT\STX\DC1\n\
+    \\EOT\ENQ\ACK\STX\DC1\DC2\EOT\135\ENQ\STX\DC1\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\DC1\SOH\DC2\EOT\235\EOT\STX\f\n\
+    \\ENQ\ENQ\ACK\STX\DC1\SOH\DC2\EOT\135\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\DC1\STX\DC2\EOT\235\EOT\SI\DLE\n\
+    \\ENQ\ENQ\ACK\STX\DC1\STX\DC2\EOT\135\ENQ\SI\DLE\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\DC2\DC2\EOT\236\EOT\STX\v\n\
+    \\EOT\ENQ\ACK\STX\DC2\DC2\EOT\136\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\DC2\SOH\DC2\EOT\236\EOT\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STX\DC2\SOH\DC2\EOT\136\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\DC2\STX\DC2\EOT\236\EOT\b\n\
+    \\ENQ\ENQ\ACK\STX\DC2\STX\DC2\EOT\136\ENQ\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\DC3\DC2\EOT\237\EOT\STX\v\n\
+    \\EOT\ENQ\ACK\STX\DC3\DC2\EOT\137\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\DC3\SOH\DC2\EOT\237\EOT\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STX\DC3\SOH\DC2\EOT\137\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\DC3\STX\DC2\EOT\237\EOT\t\n\
+    \\ENQ\ENQ\ACK\STX\DC3\STX\DC2\EOT\137\ENQ\t\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\DC4\DC2\EOT\238\EOT\STX\SO\n\
+    \\EOT\ENQ\ACK\STX\DC4\DC2\EOT\138\ENQ\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\DC4\SOH\DC2\EOT\238\EOT\STX\b\n\
+    \\ENQ\ENQ\ACK\STX\DC4\SOH\DC2\EOT\138\ENQ\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\DC4\STX\DC2\EOT\238\EOT\v\r\n\
+    \\ENQ\ENQ\ACK\STX\DC4\STX\DC2\EOT\138\ENQ\v\r\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\NAK\DC2\EOT\239\EOT\STX\f\n\
+    \\EOT\ENQ\ACK\STX\NAK\DC2\EOT\139\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\NAK\SOH\DC2\EOT\239\EOT\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STX\NAK\SOH\DC2\EOT\139\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\NAK\STX\DC2\EOT\239\EOT\t\v\n\
+    \\ENQ\ENQ\ACK\STX\NAK\STX\DC2\EOT\139\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\SYN\DC2\EOT\240\EOT\STX\DC2\n\
+    \\EOT\ENQ\ACK\STX\SYN\DC2\EOT\140\ENQ\STX\DC2\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\SYN\SOH\DC2\EOT\240\EOT\STX\f\n\
+    \\ENQ\ENQ\ACK\STX\SYN\SOH\DC2\EOT\140\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\SYN\STX\DC2\EOT\240\EOT\SI\DC1\n\
+    \\ENQ\ENQ\ACK\STX\SYN\STX\DC2\EOT\140\ENQ\SI\DC1\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\ETB\DC2\EOT\241\EOT\STX\SO\n\
+    \\EOT\ENQ\ACK\STX\ETB\DC2\EOT\141\ENQ\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\ETB\SOH\DC2\EOT\241\EOT\STX\b\n\
+    \\ENQ\ENQ\ACK\STX\ETB\SOH\DC2\EOT\141\ENQ\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\ETB\STX\DC2\EOT\241\EOT\v\r\n\
+    \\ENQ\ENQ\ACK\STX\ETB\STX\DC2\EOT\141\ENQ\v\r\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\CAN\DC2\EOT\242\EOT\STX\SO\n\
+    \\EOT\ENQ\ACK\STX\CAN\DC2\EOT\142\ENQ\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\CAN\SOH\DC2\EOT\242\EOT\STX\b\n\
+    \\ENQ\ENQ\ACK\STX\CAN\SOH\DC2\EOT\142\ENQ\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\CAN\STX\DC2\EOT\242\EOT\v\r\n\
+    \\ENQ\ENQ\ACK\STX\CAN\STX\DC2\EOT\142\ENQ\v\r\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\EM\DC2\EOT\243\EOT\STX\SO\n\
+    \\EOT\ENQ\ACK\STX\EM\DC2\EOT\143\ENQ\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\EM\SOH\DC2\EOT\243\EOT\STX\b\n\
+    \\ENQ\ENQ\ACK\STX\EM\SOH\DC2\EOT\143\ENQ\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\EM\STX\DC2\EOT\243\EOT\v\r\n\
+    \\ENQ\ENQ\ACK\STX\EM\STX\DC2\EOT\143\ENQ\v\r\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\SUB\DC2\EOT\244\EOT\STX\SO\n\
+    \\EOT\ENQ\ACK\STX\SUB\DC2\EOT\144\ENQ\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\SUB\SOH\DC2\EOT\244\EOT\STX\b\n\
+    \\ENQ\ENQ\ACK\STX\SUB\SOH\DC2\EOT\144\ENQ\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\SUB\STX\DC2\EOT\244\EOT\v\r\n\
+    \\ENQ\ENQ\ACK\STX\SUB\STX\DC2\EOT\144\ENQ\v\r\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\ESC\DC2\EOT\245\EOT\STX\f\n\
+    \\EOT\ENQ\ACK\STX\ESC\DC2\EOT\145\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\ESC\SOH\DC2\EOT\245\EOT\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STX\ESC\SOH\DC2\EOT\145\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\ESC\STX\DC2\EOT\245\EOT\t\v\n\
+    \\ENQ\ENQ\ACK\STX\ESC\STX\DC2\EOT\145\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\FS\DC2\EOT\246\EOT\STX\f\n\
+    \\EOT\ENQ\ACK\STX\FS\DC2\EOT\146\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\FS\SOH\DC2\EOT\246\EOT\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STX\FS\SOH\DC2\EOT\146\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\FS\STX\DC2\EOT\246\EOT\t\v\n\
+    \\ENQ\ENQ\ACK\STX\FS\STX\DC2\EOT\146\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\GS\DC2\EOT\247\EOT\STX\SI\n\
+    \\EOT\ENQ\ACK\STX\GS\DC2\EOT\147\ENQ\STX\SI\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\GS\SOH\DC2\EOT\247\EOT\STX\t\n\
+    \\ENQ\ENQ\ACK\STX\GS\SOH\DC2\EOT\147\ENQ\STX\t\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\GS\STX\DC2\EOT\247\EOT\f\SO\n\
+    \\ENQ\ENQ\ACK\STX\GS\STX\DC2\EOT\147\ENQ\f\SO\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\RS\DC2\EOT\248\EOT\STX\DC2\n\
+    \\EOT\ENQ\ACK\STX\RS\DC2\EOT\148\ENQ\STX\DC2\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\RS\SOH\DC2\EOT\248\EOT\STX\f\n\
+    \\ENQ\ENQ\ACK\STX\RS\SOH\DC2\EOT\148\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\RS\STX\DC2\EOT\248\EOT\SI\DC1\n\
+    \\ENQ\ENQ\ACK\STX\RS\STX\DC2\EOT\148\ENQ\SI\DC1\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\US\DC2\EOT\249\EOT\STX\DC2\n\
+    \\EOT\ENQ\ACK\STX\US\DC2\EOT\149\ENQ\STX\DC2\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\US\SOH\DC2\EOT\249\EOT\STX\f\n\
+    \\ENQ\ENQ\ACK\STX\US\SOH\DC2\EOT\149\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\US\STX\DC2\EOT\249\EOT\SI\DC1\n\
+    \\ENQ\ENQ\ACK\STX\US\STX\DC2\EOT\149\ENQ\SI\DC1\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX \DC2\EOT\250\EOT\STX\DC2\n\
+    \\EOT\ENQ\ACK\STX \DC2\EOT\150\ENQ\STX\DC2\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX \SOH\DC2\EOT\250\EOT\STX\f\n\
+    \\ENQ\ENQ\ACK\STX \SOH\DC2\EOT\150\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX \STX\DC2\EOT\250\EOT\SI\DC1\n\
+    \\ENQ\ENQ\ACK\STX \STX\DC2\EOT\150\ENQ\SI\DC1\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX!\DC2\EOT\251\EOT\STX\n\
+    \\EOT\ENQ\ACK\STX!\DC2\EOT\151\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX!\SOH\DC2\EOT\251\EOT\STX\EOT\n\
+    \\ENQ\ENQ\ACK\STX!\SOH\DC2\EOT\151\ENQ\STX\EOT\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX!\STX\DC2\EOT\251\EOT\a\t\n\
+    \\ENQ\ENQ\ACK\STX!\STX\DC2\EOT\151\ENQ\a\t\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\"\DC2\EOT\252\EOT\STX\r\n\
+    \\EOT\ENQ\ACK\STX\"\DC2\EOT\152\ENQ\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\"\SOH\DC2\EOT\252\EOT\STX\b\n\
+    \\ENQ\ENQ\ACK\STX\"\SOH\DC2\EOT\152\ENQ\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\"\STX\DC2\EOT\252\EOT\v\f\n\
+    \\ENQ\ENQ\ACK\STX\"\STX\DC2\EOT\152\ENQ\v\f\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX#\DC2\EOT\253\EOT\STX\f\n\
+    \\EOT\ENQ\ACK\STX#\DC2\EOT\153\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX#\SOH\DC2\EOT\253\EOT\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STX#\SOH\DC2\EOT\153\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX#\STX\DC2\EOT\253\EOT\t\v\n\
+    \\ENQ\ENQ\ACK\STX#\STX\DC2\EOT\153\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX$\DC2\EOT\254\EOT\STX\f\n\
+    \\EOT\ENQ\ACK\STX$\DC2\EOT\154\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX$\SOH\DC2\EOT\254\EOT\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STX$\SOH\DC2\EOT\154\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX$\STX\DC2\EOT\254\EOT\t\v\n\
+    \\ENQ\ENQ\ACK\STX$\STX\DC2\EOT\154\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX%\DC2\EOT\255\EOT\STX\DC2\n\
+    \\EOT\ENQ\ACK\STX%\DC2\EOT\155\ENQ\STX\DC2\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX%\SOH\DC2\EOT\255\EOT\STX\f\n\
+    \\ENQ\ENQ\ACK\STX%\SOH\DC2\EOT\155\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX%\STX\DC2\EOT\255\EOT\SI\DC1\n\
+    \\ENQ\ENQ\ACK\STX%\STX\DC2\EOT\155\ENQ\SI\DC1\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX&\DC2\EOT\128\ENQ\STX\SI\n\
+    \\EOT\ENQ\ACK\STX&\DC2\EOT\156\ENQ\STX\SI\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX&\SOH\DC2\EOT\128\ENQ\STX\t\n\
+    \\ENQ\ENQ\ACK\STX&\SOH\DC2\EOT\156\ENQ\STX\t\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX&\STX\DC2\EOT\128\ENQ\f\SO\n\
+    \\ENQ\ENQ\ACK\STX&\STX\DC2\EOT\156\ENQ\f\SO\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX'\DC2\EOT\129\ENQ\STX\r\n\
+    \\EOT\ENQ\ACK\STX'\DC2\EOT\157\ENQ\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX'\SOH\DC2\EOT\129\ENQ\STX\a\n\
+    \\ENQ\ENQ\ACK\STX'\SOH\DC2\EOT\157\ENQ\STX\a\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX'\STX\DC2\EOT\129\ENQ\n\
+    \\ENQ\ENQ\ACK\STX'\STX\DC2\EOT\157\ENQ\n\
     \\f\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX(\DC2\EOT\130\ENQ\STX\v\n\
+    \\EOT\ENQ\ACK\STX(\DC2\EOT\158\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX(\SOH\DC2\EOT\130\ENQ\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STX(\SOH\DC2\EOT\158\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX(\STX\DC2\EOT\130\ENQ\b\n\
+    \\ENQ\ENQ\ACK\STX(\STX\DC2\EOT\158\ENQ\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX)\DC2\EOT\131\ENQ\STX\t\n\
+    \\EOT\ENQ\ACK\STX)\DC2\EOT\159\ENQ\STX\t\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX)\SOH\DC2\EOT\131\ENQ\STX\ETX\n\
+    \\ENQ\ENQ\ACK\STX)\SOH\DC2\EOT\159\ENQ\STX\ETX\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX)\STX\DC2\EOT\131\ENQ\ACK\b\n\
+    \\ENQ\ENQ\ACK\STX)\STX\DC2\EOT\159\ENQ\ACK\b\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX*\DC2\EOT\132\ENQ\STX\f\n\
+    \\EOT\ENQ\ACK\STX*\DC2\EOT\160\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX*\SOH\DC2\EOT\132\ENQ\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STX*\SOH\DC2\EOT\160\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX*\STX\DC2\EOT\132\ENQ\t\v\n\
+    \\ENQ\ENQ\ACK\STX*\STX\DC2\EOT\160\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX+\DC2\EOT\133\ENQ\STX\v\n\
+    \\EOT\ENQ\ACK\STX+\DC2\EOT\161\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX+\SOH\DC2\EOT\133\ENQ\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STX+\SOH\DC2\EOT\161\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX+\STX\DC2\EOT\133\ENQ\t\n\
+    \\ENQ\ENQ\ACK\STX+\STX\DC2\EOT\161\ENQ\t\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX,\DC2\EOT\134\ENQ\STX\DC2\n\
+    \\EOT\ENQ\ACK\STX,\DC2\EOT\162\ENQ\STX\DC2\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX,\SOH\DC2\EOT\134\ENQ\STX\f\n\
+    \\ENQ\ENQ\ACK\STX,\SOH\DC2\EOT\162\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX,\STX\DC2\EOT\134\ENQ\SI\DC1\n\
+    \\ENQ\ENQ\ACK\STX,\STX\DC2\EOT\162\ENQ\SI\DC1\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX-\DC2\EOT\135\ENQ\STX\ETB\n\
+    \\EOT\ENQ\ACK\STX-\DC2\EOT\163\ENQ\STX\ETB\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX-\SOH\DC2\EOT\135\ENQ\STX\DC1\n\
+    \\ENQ\ENQ\ACK\STX-\SOH\DC2\EOT\163\ENQ\STX\DC1\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX-\STX\DC2\EOT\135\ENQ\DC4\SYN\n\
+    \\ENQ\ENQ\ACK\STX-\STX\DC2\EOT\163\ENQ\DC4\SYN\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX.\DC2\EOT\136\ENQ\STX\SI\n\
+    \\EOT\ENQ\ACK\STX.\DC2\EOT\164\ENQ\STX\SI\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX.\SOH\DC2\EOT\136\ENQ\STX\t\n\
+    \\ENQ\ENQ\ACK\STX.\SOH\DC2\EOT\164\ENQ\STX\t\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX.\STX\DC2\EOT\136\ENQ\f\SO\n\
+    \\ENQ\ENQ\ACK\STX.\STX\DC2\EOT\164\ENQ\f\SO\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX/\DC2\EOT\137\ENQ\STX\SO\n\
+    \\EOT\ENQ\ACK\STX/\DC2\EOT\165\ENQ\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX/\SOH\DC2\EOT\137\ENQ\STX\a\n\
+    \\ENQ\ENQ\ACK\STX/\SOH\DC2\EOT\165\ENQ\STX\a\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX/\STX\DC2\EOT\137\ENQ\v\r\n\
+    \\ENQ\ENQ\ACK\STX/\STX\DC2\EOT\165\ENQ\v\r\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX0\DC2\EOT\138\ENQ\STX\r\n\
+    \\EOT\ENQ\ACK\STX0\DC2\EOT\166\ENQ\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX0\SOH\DC2\EOT\138\ENQ\STX\b\n\
+    \\ENQ\ENQ\ACK\STX0\SOH\DC2\EOT\166\ENQ\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX0\STX\DC2\EOT\138\ENQ\v\f\n\
+    \\ENQ\ENQ\ACK\STX0\STX\DC2\EOT\166\ENQ\v\f\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX1\DC2\EOT\139\ENQ\STX\r\n\
+    \\EOT\ENQ\ACK\STX1\DC2\EOT\167\ENQ\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX1\SOH\DC2\EOT\139\ENQ\STX\a\n\
+    \\ENQ\ENQ\ACK\STX1\SOH\DC2\EOT\167\ENQ\STX\a\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX1\STX\DC2\EOT\139\ENQ\n\
+    \\ENQ\ENQ\ACK\STX1\STX\DC2\EOT\167\ENQ\n\
     \\f\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX2\DC2\EOT\140\ENQ\STX\f\n\
+    \\EOT\ENQ\ACK\STX2\DC2\EOT\168\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX2\SOH\DC2\EOT\140\ENQ\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STX2\SOH\DC2\EOT\168\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX2\STX\DC2\EOT\140\ENQ\t\v\n\
+    \\ENQ\ENQ\ACK\STX2\STX\DC2\EOT\168\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX3\DC2\EOT\141\ENQ\STX\f\n\
+    \\EOT\ENQ\ACK\STX3\DC2\EOT\169\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX3\SOH\DC2\EOT\141\ENQ\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STX3\SOH\DC2\EOT\169\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX3\STX\DC2\EOT\141\ENQ\t\v\n\
+    \\ENQ\ENQ\ACK\STX3\STX\DC2\EOT\169\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX4\DC2\EOT\142\ENQ\STX\v\n\
+    \\EOT\ENQ\ACK\STX4\DC2\EOT\170\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX4\SOH\DC2\EOT\142\ENQ\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STX4\SOH\DC2\EOT\170\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX4\STX\DC2\EOT\142\ENQ\b\n\
+    \\ENQ\ENQ\ACK\STX4\STX\DC2\EOT\170\ENQ\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX5\DC2\EOT\143\ENQ\STX\DLE\n\
+    \\EOT\ENQ\ACK\STX5\DC2\EOT\171\ENQ\STX\DLE\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX5\SOH\DC2\EOT\143\ENQ\STX\n\
+    \\ENQ\ENQ\ACK\STX5\SOH\DC2\EOT\171\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX5\STX\DC2\EOT\143\ENQ\r\SI\n\
+    \\ENQ\ENQ\ACK\STX5\STX\DC2\EOT\171\ENQ\r\SI\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX6\DC2\EOT\144\ENQ\STX\DLE\n\
+    \\EOT\ENQ\ACK\STX6\DC2\EOT\172\ENQ\STX\DLE\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX6\SOH\DC2\EOT\144\ENQ\STX\n\
+    \\ENQ\ENQ\ACK\STX6\SOH\DC2\EOT\172\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX6\STX\DC2\EOT\144\ENQ\r\SI\n\
+    \\ENQ\ENQ\ACK\STX6\STX\DC2\EOT\172\ENQ\r\SI\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX7\DC2\EOT\145\ENQ\STX\SO\n\
+    \\EOT\ENQ\ACK\STX7\DC2\EOT\173\ENQ\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX7\SOH\DC2\EOT\145\ENQ\STX\b\n\
+    \\ENQ\ENQ\ACK\STX7\SOH\DC2\EOT\173\ENQ\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX7\STX\DC2\EOT\145\ENQ\v\r\n\
+    \\ENQ\ENQ\ACK\STX7\STX\DC2\EOT\173\ENQ\v\r\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX8\DC2\EOT\146\ENQ\STX\v\n\
+    \\EOT\ENQ\ACK\STX8\DC2\EOT\174\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX8\SOH\DC2\EOT\146\ENQ\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STX8\SOH\DC2\EOT\174\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX8\STX\DC2\EOT\146\ENQ\b\n\
+    \\ENQ\ENQ\ACK\STX8\STX\DC2\EOT\174\ENQ\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX9\DC2\EOT\147\ENQ\STX\r\n\
+    \\EOT\ENQ\ACK\STX9\DC2\EOT\175\ENQ\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX9\SOH\DC2\EOT\147\ENQ\STX\a\n\
+    \\ENQ\ENQ\ACK\STX9\SOH\DC2\EOT\175\ENQ\STX\a\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX9\STX\DC2\EOT\147\ENQ\n\
+    \\ENQ\ENQ\ACK\STX9\STX\DC2\EOT\175\ENQ\n\
     \\f\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX:\DC2\EOT\148\ENQ\STX\DC3\n\
+    \\EOT\ENQ\ACK\STX:\DC2\EOT\176\ENQ\STX\DC3\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX:\SOH\DC2\EOT\148\ENQ\STX\r\n\
+    \\ENQ\ENQ\ACK\STX:\SOH\DC2\EOT\176\ENQ\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX:\STX\DC2\EOT\148\ENQ\DLE\DC2\n\
+    \\ENQ\ENQ\ACK\STX:\STX\DC2\EOT\176\ENQ\DLE\DC2\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX;\DC2\EOT\149\ENQ\STX\NAK\n\
+    \\EOT\ENQ\ACK\STX;\DC2\EOT\177\ENQ\STX\NAK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX;\SOH\DC2\EOT\149\ENQ\STX\SI\n\
+    \\ENQ\ENQ\ACK\STX;\SOH\DC2\EOT\177\ENQ\STX\SI\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX;\STX\DC2\EOT\149\ENQ\DC2\DC4\n\
+    \\ENQ\ENQ\ACK\STX;\STX\DC2\EOT\177\ENQ\DC2\DC4\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX<\DC2\EOT\150\ENQ\STX\v\n\
+    \\EOT\ENQ\ACK\STX<\DC2\EOT\178\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX<\SOH\DC2\EOT\150\ENQ\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STX<\SOH\DC2\EOT\178\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX<\STX\DC2\EOT\150\ENQ\b\n\
+    \\ENQ\ENQ\ACK\STX<\STX\DC2\EOT\178\ENQ\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX=\DC2\EOT\151\ENQ\STX\r\n\
+    \\EOT\ENQ\ACK\STX=\DC2\EOT\179\ENQ\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX=\SOH\DC2\EOT\151\ENQ\STX\a\n\
+    \\ENQ\ENQ\ACK\STX=\SOH\DC2\EOT\179\ENQ\STX\a\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX=\STX\DC2\EOT\151\ENQ\n\
+    \\ENQ\ENQ\ACK\STX=\STX\DC2\EOT\179\ENQ\n\
     \\f\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX>\DC2\EOT\152\ENQ\STX\f\n\
+    \\EOT\ENQ\ACK\STX>\DC2\EOT\180\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX>\SOH\DC2\EOT\152\ENQ\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STX>\SOH\DC2\EOT\180\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX>\STX\DC2\EOT\152\ENQ\t\v\n\
+    \\ENQ\ENQ\ACK\STX>\STX\DC2\EOT\180\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX?\DC2\EOT\153\ENQ\STX\DC2\n\
+    \\EOT\ENQ\ACK\STX?\DC2\EOT\181\ENQ\STX\DC2\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX?\SOH\DC2\EOT\153\ENQ\STX\f\n\
+    \\ENQ\ENQ\ACK\STX?\SOH\DC2\EOT\181\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX?\STX\DC2\EOT\153\ENQ\SI\DC1\n\
+    \\ENQ\ENQ\ACK\STX?\STX\DC2\EOT\181\ENQ\SI\DC1\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX@\DC2\EOT\154\ENQ\STX\SO\n\
+    \\EOT\ENQ\ACK\STX@\DC2\EOT\182\ENQ\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX@\SOH\DC2\EOT\154\ENQ\STX\b\n\
+    \\ENQ\ENQ\ACK\STX@\SOH\DC2\EOT\182\ENQ\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX@\STX\DC2\EOT\154\ENQ\v\r\n\
+    \\ENQ\ENQ\ACK\STX@\STX\DC2\EOT\182\ENQ\v\r\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXA\DC2\EOT\155\ENQ\STX\SO\n\
+    \\EOT\ENQ\ACK\STXA\DC2\EOT\183\ENQ\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXA\SOH\DC2\EOT\155\ENQ\STX\b\n\
+    \\ENQ\ENQ\ACK\STXA\SOH\DC2\EOT\183\ENQ\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXA\STX\DC2\EOT\155\ENQ\v\r\n\
+    \\ENQ\ENQ\ACK\STXA\STX\DC2\EOT\183\ENQ\v\r\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXB\DC2\EOT\156\ENQ\STX\t\n\
+    \\EOT\ENQ\ACK\STXB\DC2\EOT\184\ENQ\STX\t\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXB\SOH\DC2\EOT\156\ENQ\STX\ETX\n\
+    \\ENQ\ENQ\ACK\STXB\SOH\DC2\EOT\184\ENQ\STX\ETX\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXB\STX\DC2\EOT\156\ENQ\ACK\b\n\
+    \\ENQ\ENQ\ACK\STXB\STX\DC2\EOT\184\ENQ\ACK\b\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXC\DC2\EOT\157\ENQ\STX\SO\n\
+    \\EOT\ENQ\ACK\STXC\DC2\EOT\185\ENQ\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXC\SOH\DC2\EOT\157\ENQ\STX\b\n\
+    \\ENQ\ENQ\ACK\STXC\SOH\DC2\EOT\185\ENQ\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXC\STX\DC2\EOT\157\ENQ\v\r\n\
+    \\ENQ\ENQ\ACK\STXC\STX\DC2\EOT\185\ENQ\v\r\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXD\DC2\EOT\158\ENQ\STX\f\n\
+    \\EOT\ENQ\ACK\STXD\DC2\EOT\186\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXD\SOH\DC2\EOT\158\ENQ\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STXD\SOH\DC2\EOT\186\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXD\STX\DC2\EOT\158\ENQ\t\v\n\
+    \\ENQ\ENQ\ACK\STXD\STX\DC2\EOT\186\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXE\DC2\EOT\159\ENQ\STX\r\n\
+    \\EOT\ENQ\ACK\STXE\DC2\EOT\187\ENQ\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXE\SOH\DC2\EOT\159\ENQ\STX\a\n\
+    \\ENQ\ENQ\ACK\STXE\SOH\DC2\EOT\187\ENQ\STX\a\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXE\STX\DC2\EOT\159\ENQ\n\
+    \\ENQ\ENQ\ACK\STXE\STX\DC2\EOT\187\ENQ\n\
     \\f\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXF\DC2\EOT\160\ENQ\STX\f\n\
+    \\EOT\ENQ\ACK\STXF\DC2\EOT\188\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXF\SOH\DC2\EOT\160\ENQ\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STXF\SOH\DC2\EOT\188\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXF\STX\DC2\EOT\160\ENQ\t\v\n\
+    \\ENQ\ENQ\ACK\STXF\STX\DC2\EOT\188\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXG\DC2\EOT\161\ENQ\STX\f\n\
+    \\EOT\ENQ\ACK\STXG\DC2\EOT\189\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXG\SOH\DC2\EOT\161\ENQ\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STXG\SOH\DC2\EOT\189\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXG\STX\DC2\EOT\161\ENQ\t\v\n\
+    \\ENQ\ENQ\ACK\STXG\STX\DC2\EOT\189\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXH\DC2\EOT\162\ENQ\STX\f\n\
+    \\EOT\ENQ\ACK\STXH\DC2\EOT\190\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXH\SOH\DC2\EOT\162\ENQ\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STXH\SOH\DC2\EOT\190\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXH\STX\DC2\EOT\162\ENQ\t\v\n\
+    \\ENQ\ENQ\ACK\STXH\STX\DC2\EOT\190\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXI\DC2\EOT\163\ENQ\STX\v\n\
+    \\EOT\ENQ\ACK\STXI\DC2\EOT\191\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXI\SOH\DC2\EOT\163\ENQ\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STXI\SOH\DC2\EOT\191\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXI\STX\DC2\EOT\163\ENQ\b\n\
+    \\ENQ\ENQ\ACK\STXI\STX\DC2\EOT\191\ENQ\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXJ\DC2\EOT\164\ENQ\STX\f\n\
+    \\EOT\ENQ\ACK\STXJ\DC2\EOT\192\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXJ\SOH\DC2\EOT\164\ENQ\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STXJ\SOH\DC2\EOT\192\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXJ\STX\DC2\EOT\164\ENQ\t\v\n\
+    \\ENQ\ENQ\ACK\STXJ\STX\DC2\EOT\192\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXK\DC2\EOT\165\ENQ\STX\v\n\
+    \\EOT\ENQ\ACK\STXK\DC2\EOT\193\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXK\SOH\DC2\EOT\165\ENQ\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STXK\SOH\DC2\EOT\193\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXK\STX\DC2\EOT\165\ENQ\b\n\
+    \\ENQ\ENQ\ACK\STXK\STX\DC2\EOT\193\ENQ\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXL\DC2\EOT\166\ENQ\STX\v\n\
+    \\EOT\ENQ\ACK\STXL\DC2\EOT\194\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXL\SOH\DC2\EOT\166\ENQ\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STXL\SOH\DC2\EOT\194\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXL\STX\DC2\EOT\166\ENQ\b\n\
+    \\ENQ\ENQ\ACK\STXL\STX\DC2\EOT\194\ENQ\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXM\DC2\EOT\167\ENQ\STX\f\n\
+    \\EOT\ENQ\ACK\STXM\DC2\EOT\195\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXM\SOH\DC2\EOT\167\ENQ\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STXM\SOH\DC2\EOT\195\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXM\STX\DC2\EOT\167\ENQ\t\v\n\
+    \\ENQ\ENQ\ACK\STXM\STX\DC2\EOT\195\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXN\DC2\EOT\168\ENQ\STX\f\n\
+    \\EOT\ENQ\ACK\STXN\DC2\EOT\196\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXN\SOH\DC2\EOT\168\ENQ\STX\a\n\
+    \\ENQ\ENQ\ACK\STXN\SOH\DC2\EOT\196\ENQ\STX\a\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXN\STX\DC2\EOT\168\ENQ\n\
+    \\ENQ\ENQ\ACK\STXN\STX\DC2\EOT\196\ENQ\n\
     \\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXO\DC2\EOT\169\ENQ\STX\SO\n\
+    \\EOT\ENQ\ACK\STXO\DC2\EOT\197\ENQ\STX\SO\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXO\SOH\DC2\EOT\169\ENQ\STX\b\n\
+    \\ENQ\ENQ\ACK\STXO\SOH\DC2\EOT\197\ENQ\STX\b\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXO\STX\DC2\EOT\169\ENQ\v\r\n\
+    \\ENQ\ENQ\ACK\STXO\STX\DC2\EOT\197\ENQ\v\r\n\
     \\DC4\n\
-    \\EOT\ENQ\ACK\STXP\DC2\EOT\170\ENQ\STX\DC3\"\ACK Bash\n\
+    \\EOT\ENQ\ACK\STXP\DC2\EOT\198\ENQ\STX\DC3\"\ACK Bash\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXP\SOH\DC2\EOT\170\ENQ\STX\r\n\
+    \\ENQ\ENQ\ACK\STXP\SOH\DC2\EOT\198\ENQ\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXP\STX\DC2\EOT\170\ENQ\DLE\DC2\n\
+    \\ENQ\ENQ\ACK\STXP\STX\DC2\EOT\198\ENQ\DLE\DC2\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXQ\DC2\EOT\171\ENQ\STX\SI\n\
+    \\EOT\ENQ\ACK\STXQ\DC2\EOT\199\ENQ\STX\SI\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXQ\SOH\DC2\EOT\171\ENQ\STX\t\n\
+    \\ENQ\ENQ\ACK\STXQ\SOH\DC2\EOT\199\ENQ\STX\t\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXQ\STX\DC2\EOT\171\ENQ\f\SO\n\
+    \\ENQ\ENQ\ACK\STXQ\STX\DC2\EOT\199\ENQ\f\SO\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXR\DC2\EOT\172\ENQ\STX\f\n\
+    \\EOT\ENQ\ACK\STXR\DC2\EOT\200\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXR\SOH\DC2\EOT\172\ENQ\STX\a\n\
+    \\ENQ\ENQ\ACK\STXR\SOH\DC2\EOT\200\ENQ\STX\a\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXR\STX\DC2\EOT\172\ENQ\n\
+    \\ENQ\ENQ\ACK\STXR\STX\DC2\EOT\200\ENQ\n\
     \\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXS\DC2\EOT\173\ENQ\STX\f\n\
+    \\EOT\ENQ\ACK\STXS\DC2\EOT\201\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXS\SOH\DC2\EOT\173\ENQ\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STXS\SOH\DC2\EOT\201\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXS\STX\DC2\EOT\173\ENQ\t\v\n\
+    \\ENQ\ENQ\ACK\STXS\STX\DC2\EOT\201\ENQ\t\v\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXT\DC2\EOT\174\ENQ\STX\v\n\
+    \\EOT\ENQ\ACK\STXT\DC2\EOT\202\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXT\SOH\DC2\EOT\174\ENQ\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STXT\SOH\DC2\EOT\202\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXT\STX\DC2\EOT\174\ENQ\b\n\
+    \\ENQ\ENQ\ACK\STXT\STX\DC2\EOT\202\ENQ\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXU\DC2\EOT\175\ENQ\STX\DC2\n\
+    \\EOT\ENQ\ACK\STXU\DC2\EOT\203\ENQ\STX\DC2\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXU\SOH\DC2\EOT\175\ENQ\STX\f\n\
+    \\ENQ\ENQ\ACK\STXU\SOH\DC2\EOT\203\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXU\STX\DC2\EOT\175\ENQ\SI\DC1\n\
+    \\ENQ\ENQ\ACK\STXU\STX\DC2\EOT\203\ENQ\SI\DC1\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXV\DC2\EOT\176\ENQ\STX\ETB\n\
+    \\EOT\ENQ\ACK\STXV\DC2\EOT\204\ENQ\STX\ETB\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXV\SOH\DC2\EOT\176\ENQ\STX\DC1\n\
+    \\ENQ\ENQ\ACK\STXV\SOH\DC2\EOT\204\ENQ\STX\DC1\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXV\STX\DC2\EOT\176\ENQ\DC4\SYN\n\
+    \\ENQ\ENQ\ACK\STXV\STX\DC2\EOT\204\ENQ\DC4\SYN\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXW\DC2\EOT\177\ENQ\STX\DC3\n\
+    \\EOT\ENQ\ACK\STXW\DC2\EOT\205\ENQ\STX\DC3\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXW\SOH\DC2\EOT\177\ENQ\STX\r\n\
+    \\ENQ\ENQ\ACK\STXW\SOH\DC2\EOT\205\ENQ\STX\r\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXW\STX\DC2\EOT\177\ENQ\DLE\DC2\n\
+    \\ENQ\ENQ\ACK\STXW\STX\DC2\EOT\205\ENQ\DLE\DC2\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXX\DC2\EOT\178\ENQ\STX\v\n\
+    \\EOT\ENQ\ACK\STXX\DC2\EOT\206\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXX\SOH\DC2\EOT\178\ENQ\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STXX\SOH\DC2\EOT\206\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXX\STX\DC2\EOT\178\ENQ\b\n\
+    \\ENQ\ENQ\ACK\STXX\STX\DC2\EOT\206\ENQ\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXY\DC2\EOT\179\ENQ\STX\SI\n\
+    \\EOT\ENQ\ACK\STXY\DC2\EOT\207\ENQ\STX\SI\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXY\SOH\DC2\EOT\179\ENQ\STX\t\n\
+    \\ENQ\ENQ\ACK\STXY\SOH\DC2\EOT\207\ENQ\STX\t\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXY\STX\DC2\EOT\179\ENQ\f\SO\n\
+    \\ENQ\ENQ\ACK\STXY\STX\DC2\EOT\207\ENQ\f\SO\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STXZ\DC2\EOT\180\ENQ\STX\v\n\
+    \\EOT\ENQ\ACK\STXZ\DC2\EOT\208\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXZ\SOH\DC2\EOT\180\ENQ\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STXZ\SOH\DC2\EOT\208\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STXZ\STX\DC2\EOT\180\ENQ\b\n\
+    \\ENQ\ENQ\ACK\STXZ\STX\DC2\EOT\208\ENQ\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX[\DC2\EOT\181\ENQ\STX\v\n\
+    \\EOT\ENQ\ACK\STX[\DC2\EOT\209\ENQ\STX\v\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX[\SOH\DC2\EOT\181\ENQ\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STX[\SOH\DC2\EOT\209\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX[\STX\DC2\EOT\181\ENQ\b\n\
+    \\ENQ\ENQ\ACK\STX[\STX\DC2\EOT\209\ENQ\b\n\
     \\n\
     \\f\n\
-    \\EOT\ENQ\ACK\STX\\\DC2\EOT\182\ENQ\STX\f\n\
+    \\EOT\ENQ\ACK\STX\\\DC2\EOT\210\ENQ\STX\f\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\\\SOH\DC2\EOT\182\ENQ\STX\ACK\n\
+    \\ENQ\ENQ\ACK\STX\\\SOH\DC2\EOT\210\ENQ\STX\ACK\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX\\\STX\DC2\EOT\182\ENQ\t\v\n\
+    \\ENQ\ENQ\ACK\STX\\\STX\DC2\EOT\210\ENQ\t\v\n\
     \\146\ETX\n\
-    \\EOT\ENQ\ACK\STX]\DC2\EOT\183\ENQ\STX\v\"\131\ETX NextLanguage = 95;\n\
+    \\EOT\ENQ\ACK\STX]\DC2\EOT\211\ENQ\STX\v\"\131\ETX NextLanguage = 95;\n\
     \ Steps add a new language:\n\
     \ 1. Copy-paste the \"NextLanguage = N\" line above\n\
     \ 2. Increment \"NextLanguage = N\" to \"NextLanguage = N+1\"\n\
@@ -8069,7 +8285,7 @@ packedFileDescriptor
     \ 5. (optional) Add a brief comment behind the language if the name is not self-explanatory\n\
     \\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX]\SOH\DC2\EOT\183\ENQ\STX\ENQ\n\
+    \\ENQ\ENQ\ACK\STX]\SOH\DC2\EOT\211\ENQ\STX\ENQ\n\
     \\r\n\
-    \\ENQ\ENQ\ACK\STX]\STX\DC2\EOT\183\ENQ\b\n\
+    \\ENQ\ENQ\ACK\STX]\STX\DC2\EOT\211\ENQ\b\n\
     \b\ACKproto3"

--- a/bindings/haskell/src/Proto/Scip_Fields.hs
+++ b/bindings/haskell/src/Proto/Scip_Fields.hs
@@ -1,4 +1,4 @@
-{- This file was auto-generated from scip.proto by the proto-lens-protoc program. -}
+{- This file was auto-generated from scip.proto by the protoc-gen-haskell program. -}
 {-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies, UndecidableInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, PatternSynonyms, MagicHash, NoImplicitPrelude, DataKinds, BangPatterns, TypeApplications, OverloadedStrings, DerivingStrategies#-}
 {-# OPTIONS_GHC -Wno-unused-imports#-}
 {-# OPTIONS_GHC -Wno-duplicate-exports#-}
@@ -56,6 +56,12 @@ disambiguator ::
    Data.ProtoLens.Field.HasField s "disambiguator" a) =>
   Lens.Family2.LensLike' f s a
 disambiguator = Data.ProtoLens.Field.field @"disambiguator"
+displayName ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "displayName" a) =>
+  Lens.Family2.LensLike' f s a
+displayName = Data.ProtoLens.Field.field @"displayName"
 documentation ::
   forall f s a.
   (Prelude.Functor f,
@@ -132,6 +138,13 @@ maybe'package ::
    Data.ProtoLens.Field.HasField s "maybe'package" a) =>
   Lens.Family2.LensLike' f s a
 maybe'package = Data.ProtoLens.Field.field @"maybe'package"
+maybe'signatureDocumentation ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'signatureDocumentation" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'signatureDocumentation
+  = Data.ProtoLens.Field.field @"maybe'signatureDocumentation"
 maybe'toolInfo ::
   forall f s a.
   (Prelude.Functor f,
@@ -206,6 +219,13 @@ severity ::
    Data.ProtoLens.Field.HasField s "severity" a) =>
   Lens.Family2.LensLike' f s a
 severity = Data.ProtoLens.Field.field @"severity"
+signatureDocumentation ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "signatureDocumentation" a) =>
+  Lens.Family2.LensLike' f s a
+signatureDocumentation
+  = Data.ProtoLens.Field.field @"signatureDocumentation"
 source ::
   forall f s a.
   (Prelude.Functor f, Data.ProtoLens.Field.HasField s "source" a) =>
@@ -243,6 +263,11 @@ tags ::
   (Prelude.Functor f, Data.ProtoLens.Field.HasField s "tags" a) =>
   Lens.Family2.LensLike' f s a
 tags = Data.ProtoLens.Field.field @"tags"
+text ::
+  forall f s a.
+  (Prelude.Functor f, Data.ProtoLens.Field.HasField s "text" a) =>
+  Lens.Family2.LensLike' f s a
+text = Data.ProtoLens.Field.field @"text"
 textDocumentEncoding ::
   forall f s a.
   (Prelude.Functor f,

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -16,3 +16,5 @@ plugins:
   - name: rust
     path: ./.bin/bin/protoc-gen-rust
     out: ./bindings/rust/src/generated/
+  - name: haskell
+    out: ./bindings/haskell/src

--- a/dev/proto-generate.sh
+++ b/dev/proto-generate.sh
@@ -19,7 +19,7 @@ fi
 
 echo "--- Haskell ---"
 command -v cabal > /dev/null 2>&1 || { echo >&2 "Haskell's 'cabal' command is not installed. Please install it first via https://www.haskell.org/ghcup/"; exit 1; }
-cabal install proto-lens-protoc --overwrite-policy=always
+cabal install proto-lens-protoc-0.7.1.1 --overwrite-policy=always
 ln -sfv `which proto-lens-protoc` "$PWD/.bin/protoc-gen-haskell"
 PATH="$PWD/.bin:$PATH"
 

--- a/dev/proto-generate.sh
+++ b/dev/proto-generate.sh
@@ -16,6 +16,13 @@ if ! grep -q "$PROTOC_GEN_RUST_VERSION" "./.bin/PROTOC_GEN_RUST_VERSION" \
   echo "$PROTOC_GEN_RUST_VERSION" > "./.bin/PROTOC_GEN_RUST_VERSION"
 fi
 
+
+echo "--- Haskell ---"
+command -v cabal > /dev/null 2>&1 || { echo >&2 "Haskell's 'cabal' command is not installed. Please install it first via https://www.haskell.org/ghcup/"; exit 1; }
+cabal install proto-lens-protoc --overwrite-policy=always
+ln -sfv `which proto-lens-protoc` "$PWD/.bin/protoc-gen-haskell"
+PATH="$PWD/.bin:$PATH"
+
 echo "--- buf ---"
 
 # Keep in sync with bindings/go/scip/tools.go
@@ -23,6 +30,7 @@ GOBIN="$PWD/.bin" go install github.com/bufbuild/buf/cmd/buf
 GOBIN="$PWD/.bin" go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
 GOBIN="$PWD/.bin" go install golang.org/x/tools/cmd/goimports
 GOBIN="$PWD/.bin" go install google.golang.org/protobuf/cmd/protoc-gen-go
+
 
 GOBIN="$PWD/.bin" ./.bin/buf generate
 ./.bin/goimports -w ./bindings/go/scip/scip.pb.go

--- a/dev/proto-generate.sh
+++ b/dev/proto-generate.sh
@@ -19,7 +19,7 @@ fi
 
 echo "--- Haskell ---"
 command -v cabal > /dev/null 2>&1 || { echo >&2 "Haskell's 'cabal' command is not installed. Please install it first via https://www.haskell.org/ghcup/"; exit 1; }
-cabal install proto-lens-protoc-0.7.1.1 --overwrite-policy=always
+cabal install proto-lens-protoc-0.7.1.1 --overwrite-policy=always --ghc-options='-j2 +RTS -A32m'
 ln -sfv `which proto-lens-protoc` "$PWD/.bin/protoc-gen-haskell"
 PATH="$PWD/.bin:$PATH"
 


### PR DESCRIPTION
Supersedes https://github.com/sourcegraph/scip/pull/146

Previously, the Haskell bindings became outdated as soon as we made changes to the SCIP spec. This PR adds Haskell binding generation to the `proto-generate.sh` script so that the Haskell bindings are automatically kept up-to-date as we make changes to the spec.

### Test plan
Green CI.