### PR TITLE
formatter: Fix escaping logic

### DIFF
--- a/bindings/go/scip/symbol_formatter_test.go
+++ b/bindings/go/scip/symbol_formatter_test.go
@@ -1,0 +1,50 @@
+package scip
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSymbolFormatter(t *testing.T) {
+	expected := "zeroth  escape first  escape second  escape third  escape `github.com/foo/``bar/n2/n3/n4`/T#f()."
+	symbol := &Symbol{
+		Scheme: "zeroth escape",
+		Package: &Package{
+			Manager: "first escape",
+			Name:    "second escape",
+			Version: "third escape",
+		},
+		Descriptors: []*Descriptor{
+			{Name: "github.com/foo/`bar/n2/n3/n4", Suffix: Descriptor_Namespace},
+			{Name: "T", Suffix: Descriptor_Type},
+			{Name: "f", Suffix: Descriptor_Method},
+		},
+	}
+
+	if diff := cmp.Diff(expected, VerboseSymbolFormatter.FormatSymbol(symbol)); diff != "" {
+		t.Fatalf("unexpected response (-want +got):\n%s", diff)
+	}
+}
+
+func TestSymbolFormatterRoundTrip(t *testing.T) {
+	type test struct {
+		Symbol string
+	}
+	tests := []test{
+		{"lsif-java maven package 1.0.0 java/io/File#Entry.method(+1).(param)[TypeParam]"},
+		{"rust-analyzer cargo std 1.0.0 macros/println!"},
+		{"mod first  escape second  escape third  escape `github.com/foo/``bar/n2/n3/n4`/T#f()."},
+	}
+	for _, test := range tests {
+		t.Run(test.Symbol, func(t *testing.T) {
+			formatted, err := VerboseSymbolFormatter.Format(test.Symbol)
+			require.Nil(t, err)
+
+			if diff := cmp.Diff(test.Symbol, formatted); diff != "" {
+				t.Fatalf("unexpected response (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/bindings/go/scip/symbol_formatter_test.go
+++ b/bindings/go/scip/symbol_formatter_test.go
@@ -35,7 +35,7 @@ func TestSymbolFormatterRoundTrip(t *testing.T) {
 	tests := []test{
 		{"lsif-java maven package 1.0.0 java/io/File#Entry.method(+1).(param)[TypeParam]"},
 		{"rust-analyzer cargo std 1.0.0 macros/println!"},
-		{"mod first  escape second  escape third  escape `github.com/foo/``bar/n2/n3/n4`/T#f()."},
+		{"zeroth  escape first  escape second  escape third  escape `github.com/foo/``bar/n2/n3/n4`/T#f()."},
 	}
 	for _, test := range tests {
 		t.Run(test.Symbol, func(t *testing.T) {


### PR DESCRIPTION
We were failing to escape the SCIP identifier names on formatting.

### Test plan

New unit tests