### PR TITLE
Add `--project-root` flag to `scip stats`

### DIFF
--- a/bindings/go/scip/testutil/format.go
+++ b/bindings/go/scip/testutil/format.go
@@ -33,7 +33,7 @@ func FormatSnapshots(
 	} else if _, err := os.Stat(localSourcesRoot); errors.Is(err, os.ErrNotExist) {
 		cwd, _ := os.Getwd()
 		log.Printf("Project root [%s] doesn't exist, using current working directory [%s] instead. "+
-			"To override this behaviour, use --root=<folder> option directly", projectRootUrl.Path, cwd)
+			"To override this behaviour, use --project-root=<folder> option directly", projectRootUrl.Path, cwd)
 		localSourcesRoot = cwd
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,3 +74,12 @@ func fromFlag(storage *string) *cli.StringFlag {
 		Value:       "index.scip",
 	}
 }
+
+func projectRootFlag(storage *string) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name: "project-root",
+		Usage: "Override project root in the SCIP file. " +
+			"This can be helpful when the SCIP index was created on another computer",
+		Destination: storage,
+	}
+}

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -37,12 +37,7 @@ and symbol information.`,
 				Destination: &snapshotFlags.output,
 				Value:       "scip-snapshot",
 			},
-			&cli.StringFlag{
-				Name: "project-root",
-				Usage: "Override project root in the SCIP file. " +
-					"For example, this can be helpful when the SCIP index was created inside a Docker image or created on another computer",
-				Destination: &snapshotFlags.customProjectRoot,
-			},
+			projectRootFlag(&snapshotFlags.customProjectRoot),
 			&cli.BoolFlag{
 				Name:        "strict",
 				Usage:       "If true, fail fast on errors",

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -40,7 +40,7 @@ func statsMain(flags statsFlags) error {
 	from := flags.from
 	index, err := readFromOption(from)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error reading SCIP file")
 	}
 	if index.Metadata == nil {
 		return errors.Errorf("Index.Metadata is nil (--from=%s)", from)
@@ -48,7 +48,7 @@ func statsMain(flags statsFlags) error {
 	output := map[string]interface{}{}
 	indexStats, err := countStatistics(index)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error counting stats")
 	}
 	jsonBytes, err := json.MarshalIndent(indexStats, "", "  ")
 	if err != nil {
@@ -97,7 +97,7 @@ func countLinesOfCode(index *scip.Index) (*gocloc.Result, error) {
 		return nil, err
 	}
 	if !stat.IsDir() {
-		return nil, errors.Errorf("index.Metadata.ProjectRoot is not a directory: %s", root.Path)
+		return nil, errors.Errorf("Project root [%s] is not a directory", localSource)
 	}
 	processor := gocloc.NewProcessor(gocloc.NewDefinedLanguages(), gocloc.NewClocOptions())
 	var paths []string

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -16,7 +16,8 @@ import (
 )
 
 type statsFlags struct {
-	from string
+	from              string
+	customProjectRoot string
 }
 
 func statsCommand() cli.Command {
@@ -24,7 +25,10 @@ func statsCommand() cli.Command {
 	stats := cli.Command{
 		Name:  "stats",
 		Usage: "Output useful statistics about a SCIP index",
-		Flags: []cli.Flag{fromFlag(&statsFlags.from)},
+		Flags: []cli.Flag{
+			fromFlag(&statsFlags.from),
+			projectRootFlag(&statsFlags.customProjectRoot),
+		},
 		Action: func(c *cli.Context) error {
 			return statsMain(statsFlags)
 		},


### PR DESCRIPTION
Workaround for https://github.com/sourcegraph/scip/issues/98

This shares logic with `bindings/go/scip/testutil/format.go`, but I haven't found the best place to put this shared code.

### Test plan

```sh
$ go build -o scip ./cmd && ./scip stats --from /tmp/index.scip --project-root /data/s/gdk
{
  "documents": 222,
  "linesOfCode": 14789,
  "occurrences": 11324,
  "definitions": 2908
}
```
```sh
$ go build -o scip ./cmd && ./scip stats --from /tmp/index.scip                          
2023/07/19 17:51:48 Project root [/s/gdk] doesn't exist, using current working directory [/home/anatoli/delme/scip] instead. To override this behaviour, specify --project-root=<folder> option
2023/07/19 17:51:48 error counting stats: lstat /home/anatoli/delme/scip/support/compare.rb: no such file or directory 
```