### PR TITLE
Stop sorting CLI options

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -45,7 +45,7 @@ func TestCLIReferenceInSync(t *testing.T) {
 		require.Nil(t, err)
 		help := strings.TrimSpace(string(helpBytes))
 		require.Truef(t, strings.Contains(readme, help),
-			"Readme.md missing help text %s for %s.\nRun `%s` and paste the output in the Readme.",
+			"docs/CLI.md missing help text %s for %s.\nRun `%s` and paste the output in the Readme.",
 			help, commandName, strings.Join(append([]string{"scip"}, args...), " "))
 	}
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -34,9 +34,8 @@ COMMANDS:
    help, h   Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --help, -h     show help (default: false)
-   --version, -v  print the version (default: false)
-
+   --help, -h     show help
+   --version, -v  print the version
 ```
 
 ## `scip convert`
@@ -69,9 +68,6 @@ DESCRIPTION:
 
    You may want to filter the output using `grep -v <pattern>`
    to narrow down on certain classes of errors.
-
-OPTIONS:
-   --help, -h  show help (default: false)
 ```
 
 ## `scip print`
@@ -88,7 +84,6 @@ DESCRIPTION:
    Do not rely on the output of this command in scripts
 
 OPTIONS:
-   --help, -h  show help (default: false)
    --json      Output in JSON format (default: false)
 ```
 
@@ -108,12 +103,11 @@ DESCRIPTION:
    and symbol information.
 
 OPTIONS:
-   --comment-syntax value  Comment syntax to use for snapshot files (default: "//")
    --from value            Path to SCIP index file (default: "index.scip")
-   --help, -h              show help (default: false)
+   --to value              Path to output directory for snapshot files (default: "scip-snapshot")
    --project-root value    Override project root in the SCIP file. For example, this can be helpful when the SCIP index was created inside a Docker image or created on another computer
    --strict                If true, fail fast on errors (default: true)
-   --to value              Path to output directory for snapshot files (default: "scip-snapshot")
+   --comment-syntax value  Comment syntax to use for snapshot files (default: "//")
 ```
 
 ## `scip stats`

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/smacker/go-tree-sitter v0.0.0-20220209044044-0d3022e933c3
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20220511160847-5a43d3ea24eb
 	github.com/stretchr/testify v1.7.1
-	github.com/urfave/cli/v2 v2.19.3
+	github.com/urfave/cli/v2 v2.25.7
 	golang.org/x/tools v0.1.10
 	google.golang.org/protobuf v1.28.0
 )

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/smacker/go-tree-sitter v0.0.0-20220209044044-0d3022e933c3
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20220511160847-5a43d3ea24eb
 	github.com/stretchr/testify v1.7.1
-	github.com/urfave/cli/v2 v2.19.1
+	github.com/urfave/cli/v2 v2.19.3
 	golang.org/x/tools v0.1.10
 	google.golang.org/protobuf v1.28.0
 )

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
-github.com/urfave/cli/v2 v2.19.3 h1:GsJ5D2qZWF6hk/F276qqf8v/Ff4IzAUTB+CUFSNhN6M=
-github.com/urfave/cli/v2 v2.19.3/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
+github.com/urfave/cli/v2 v2.25.7 h1:VAzn5oq403l5pHjc4OhD54+XGO9cdKVL/7lDjF+iKUs=
+github.com/urfave/cli/v2 v2.25.7/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBnvPM1Su9w=

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
-github.com/urfave/cli/v2 v2.19.1 h1:5Lt6gp6VugLvDmsyl80uqZlmCn/gyI9af8JvC2voqCI=
-github.com/urfave/cli/v2 v2.19.1/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
+github.com/urfave/cli/v2 v2.19.3 h1:GsJ5D2qZWF6hk/F276qqf8v/Ff4IzAUTB+CUFSNhN6M=
+github.com/urfave/cli/v2 v2.19.3/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBnvPM1Su9w=


### PR DESCRIPTION
Fixed in https://github.com/urfave/cli/releases/tag/v2.19.2

### Test plan
```sh
scip snapshot -h
```

**Before**
```
OPTIONS:
   --comment-syntax value  Comment syntax to use for snapshot files (default: "//")
   --from value            Path to SCIP index file (default: "index.scip")
   --help, -h              show help (default: false)
   --project-root value    Override project root in the SCIP file. For example, this can be helpful when the SCIP index was created inside a Docker image or created on another computer
   --strict                If true, fail fast on errors (default: true)
   --to value              Path to output directory for snapshot files (default: "scip-snapshot")
```

**After**
```
OPTIONS:
   --from value            Path to SCIP index file (default: "index.scip")
   --to value              Path to output directory for snapshot files (default: "scip-snapshot")
   --project-root value    Override project root in the SCIP file. For example, this can be helpful when the SCIP index was created inside a Docker image or created on another computer
   --strict                If true, fail fast on errors (default: true)
   --comment-syntax value  Comment syntax to use for snapshot files (default: "//")
   --help, -h              show help (default: false) 
```