### PR TITLE
Disable typechecking of autogenerated scip.ts bindings

### DIFF
--- a/bindings/typescript/scip.ts
+++ b/bindings/typescript/scip.ts
@@ -5,6 +5,7 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 export namespace scip {
+    export const removeMeAfteGreenCI: number = 'hello'
     export enum ProtocolVersion {
         UnspecifiedProtocolVersion = 0
     }

--- a/bindings/typescript/tsconfig.json
+++ b/bindings/typescript/tsconfig.json
@@ -4,5 +4,6 @@
     "module": "commonjs",
     "rootDir": ".",
     "strict": true
-  }
+  },
+  "exclude": ["scip.ts"]
 }


### PR DESCRIPTION
Attempt to fix https://github.com/sourcegraph/scip/issues/149

### Test plan
Green CI.