### PR TITLE
Included diagnostics in `scip snapshot` output

### DIFF
--- a/bindings/go/scip/testutil/format.go
+++ b/bindings/go/scip/testutil/format.go
@@ -17,6 +17,7 @@ import (
 // that is suitable for snapshot testing.
 func FormatSnapshots(
 	index *scip.Index,
+	includeDiagnostics bool,
 	commentSyntax string,
 	symbolFormatter scip.SymbolFormatter,
 	customProjectRoot string,
@@ -40,7 +41,7 @@ func FormatSnapshots(
 	var documentErrors error
 	for _, document := range index.Documents {
 		sourceFilePath := filepath.Join(localSourcesRoot, document.RelativePath)
-		snapshot, err := FormatSnapshot(document, index, commentSyntax, symbolFormatter, sourceFilePath)
+		snapshot, err := FormatSnapshot(document, index, includeDiagnostics, commentSyntax, symbolFormatter, sourceFilePath)
 		err = symbolFormatter.OnError(err)
 		if err != nil {
 			documentErrors = errors.CombineErrors(
@@ -65,6 +66,7 @@ func FormatSnapshots(
 func FormatSnapshot(
 	document *scip.Document,
 	index *scip.Index,
+	includeDiagnostics bool,
 	commentSyntax string,
 	formatter scip.SymbolFormatter,
 	sourceFilePath string,
@@ -149,6 +151,14 @@ func FormatSnapshot(
 					if relationship.IsTypeDefinition {
 						b.WriteString(" type_definition")
 					}
+				}
+			}
+
+			if includeDiagnostics {
+				for _, diagnostic := range occ.Diagnostics {
+					b.WriteString(prefix)
+					b.WriteString("diagnostic ")
+					b.WriteString(diagnostic.Code)
 				}
 			}
 

--- a/cmd/scip/main_test.go
+++ b/cmd/scip/main_test.go
@@ -92,7 +92,7 @@ func TestSCIPSnapshots(t *testing.T) {
 		require.Nil(t, err)
 		symbolFormatter := scip.DescriptorOnlyFormatter
 		symbolFormatter.IncludePackageName = func(name string) bool { return name != testName }
-		snapshots, err := testutil.FormatSnapshots(index, "#", symbolFormatter, inputDirectory)
+		snapshots, err := testutil.FormatSnapshots(index, false, "#", symbolFormatter, inputDirectory)
 		require.Nil(t, err)
 		if debugSnapshotAbspaths != nil && *debugSnapshotAbspaths {
 			inputDirAbsPath, err := filepath.Abs(inputDirectory)

--- a/cmd/scip/snapshot.go
+++ b/cmd/scip/snapshot.go
@@ -13,11 +13,12 @@ import (
 )
 
 type snapshotFlags struct {
-	from              string
-	output            string
-	customProjectRoot string
-	strict            bool
-	commentSyntax     string
+	from               string
+	output             string
+	includeDiagnostics bool
+	customProjectRoot  string
+	strict             bool
+	commentSyntax      string
 }
 
 func snapshotCommand() cli.Command {
@@ -43,6 +44,12 @@ and symbol information.`,
 				Usage:       "If true, fail fast on errors",
 				Destination: &snapshotFlags.strict,
 				Value:       true,
+			},
+			&cli.BoolFlag{
+				Name:        "include-diagnostics",
+				Usage:       "Whether or not to include scip diagnostics in snapshot files",
+				Destination: &snapshotFlags.includeDiagnostics,
+				Value:       false,
 			},
 			&cli.StringFlag{
 				Name:        "comment-syntax",
@@ -76,7 +83,7 @@ func snapshotMain(flags snapshotFlags) error {
 			return errors.Wrap(err, "use --strict=false to ignore this error")
 		}
 	}
-	snapshots, err := testutil.FormatSnapshots(index, flags.commentSyntax, symbolFormatter, flags.customProjectRoot)
+	snapshots, err := testutil.FormatSnapshots(index, flags.includeDiagnostics, flags.commentSyntax, symbolFormatter, flags.customProjectRoot)
 	if err != nil {
 		return err
 	}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -107,6 +107,7 @@ OPTIONS:
    --to value              Path to output directory for snapshot files (default: "scip-snapshot")
    --project-root value    Override project root in the SCIP file. For example, this can be helpful when the SCIP index was created inside a Docker image or created on another computer
    --strict                If true, fail fast on errors (default: true)
+   --include-diagnostics   Whether or not to include scip diagnostics in snapshot files (default: false)
    --comment-syntax value  Comment syntax to use for snapshot files (default: "//")
 ```
 


### PR DESCRIPTION
This concept originally came out of [this issue](https://github.com/Workiva/scip-dart/issues/98), which was individually reported in `sourcegraph/scip` within [this issue](https://github.com/sourcegraph/scip/issues/213)

Adds the option to include indexed diagnostics to the results of `scip snapshot`

This functionality is explicitly enabled via the `--include-diagnostics` flag, to support backwards compatibility with current  snapshot tests (eg, the inclusion of `diagnostics` in snapshot files is opt-in)

Example format is as follows:

- Given this example dart file
    ```dart
    void _unusedElement() {}
    ```
- Running `scip snapshot --include-diagnostics` will result in
   ```dart
      void _unusedElement() {}
   //      ^^^^^^^^^^^^^^ definition scip-dart pub test_package lib/main.dart _unusedElement().
  //      diagnostic UNUSED_ELEMENT
   ```

### Test plan
- I've verified the functionality myself on various indexed scip files, but when attempting to write some unit tests around the new functionality, I was a bit confused on the current test setup, specifically around `repolang` and how to add diagnostic concepts to it. I'm open to suggestions / contributions to the pr addressing this missing test coverage