### PR TITLE
ci: Try using older version of ghc-source-gen

### DIFF
--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -9,6 +9,7 @@ on:
       - 'scip.proto'
       - 'buf**'
       - '.tool-versions'
+      - 'dev/proto-generate.sh'
 
 jobs:
   protoc-gen-up-to-date:

--- a/dev/proto-generate.sh
+++ b/dev/proto-generate.sh
@@ -19,7 +19,7 @@ fi
 
 echo "--- Haskell ---"
 command -v cabal > /dev/null 2>&1 || { echo >&2 "Haskell's 'cabal' command is not installed. Please install it first via https://www.haskell.org/ghcup/"; exit 1; }
-cabal install proto-lens-protoc-0.7.1.1 --overwrite-policy=always --ghc-options='-j2 +RTS -A32m'
+cabal install proto-lens-protoc-0.7.1.1 ghc-source-gen-0.4.3.0 --overwrite-policy=always --ghc-options='-j2 +RTS -A32m'
 ln -sfv `which proto-lens-protoc` "$PWD/.bin/protoc-gen-haskell"
 PATH="$PWD/.bin:$PATH"
 


### PR DESCRIPTION
There seems to be a build failure with ghc-source-gen-0.4.4.0 when
using GHC 8.10, so attempt to tell cabal to use an older version.

```
 src/GHC/SourceGen/Module.hs:191:41: error:
Error:     Variable not in scope: unqual :: OccNameStr -> RdrNameStr
    |
191 |                     (map (wrappedName . unqual) cs)
    |                                         ^^^^^^
Error: cabal: Failed to build ghc-source-gen-0.4.4.0 (which is required by
exe:proto-lens-protoc from proto-lens-protoc-0.7.1.1). See the build log above
for details.
```

Source: https://github.com/sourcegraph/scip/actions/runs/7322644181/job/19944384186?pr=226

### Test plan

CI passes