### PR TITLE
bindings/go: Add common APIs for Range and Position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ SCIP schema:
 
 - Added documentation that ranges must be half-open intervals.
 
+Go SCIP bindings:
+
+- Breaking changes:
+  - The `NewRange` function now returns `Range` instead of `*Range`.
+  - The `SortRanges` function takes a `[]Range` instead of a `[]*Range`
+    to avoid extra heap allocations.
+- Features:
+  - Added new methods for `Range` and `Position` types.
+
 ## v0.3.3
 
 SCIP schema:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ SCIP schema:
 Go SCIP bindings:
 
 - Breaking changes:
-  - The `NewRange` function now returns `Range` instead of `*Range`.
+  - The `NewRange` function does well-formedness checks and returns `(Range, error)` instead of `*Range`.
+    When skipping checks, `NewRangeUnchecked` can be used instead.
   - The `SortRanges` function takes a `[]Range` instead of a `[]*Range`
     to avoid extra heap allocations.
 - Features:

--- a/bindings/go/scip/canonicalize.go
+++ b/bindings/go/scip/canonicalize.go
@@ -36,7 +36,7 @@ func RemoveIllegalOccurrences(occurrences []*Occurrence) []*Occurrence {
 // CanonicalizeOccurrence deterministically re-orders the fields of the given occurrence.
 func CanonicalizeOccurrence(occurrence *Occurrence) *Occurrence {
 	// Express ranges as three-components if possible
-	occurrence.Range = NewRange(occurrence.Range).SCIPRange()
+	occurrence.Range = NewRangeUnchecked(occurrence.Range).SCIPRange()
 	occurrence.Diagnostics = CanonicalizeDiagnostics(occurrence.Diagnostics)
 	return occurrence
 }

--- a/bindings/go/scip/position.go
+++ b/bindings/go/scip/position.go
@@ -1,6 +1,9 @@
 package scip
 
-// Range represents a range between two offset positions.
+import "fmt"
+
+// Range represents [start, end) between two offset positions.
+//
 // NOTE: the github.com/sourcegraph/sourcegraph/lib/codeintel/lsif/protocol package
 // contains similarly shaped structs but this one exists primarily to make it
 // easier to work with SCIP encoded positions, which have the type []int32
@@ -16,18 +19,45 @@ type Position struct {
 	Character int32
 }
 
-// NewRange converts an SCIP range into `Range`
-func NewRange(scipRange []int32) *Range {
-	var endLine int32
-	var endCharacter int32
-	if len(scipRange) == 3 { // single line
-		endLine = scipRange[0]
-		endCharacter = scipRange[2]
-	} else if len(scipRange) == 4 { // multi-line
-		endLine = scipRange[2]
-		endCharacter = scipRange[3]
+func (p Position) Compare(other Position) int {
+	if p.Line < other.Line {
+		return -1
 	}
-	return &Range{
+	if p.Line > other.Line {
+		return 1
+	}
+	if p.Character < other.Character {
+		return -1
+	}
+	if p.Character > other.Character {
+		return 1
+	}
+	return 0
+}
+
+func (p Position) Less(other Position) bool {
+	if p.Line < other.Line {
+		return true
+	}
+	if p.Line > other.Line {
+		return false
+	}
+	return p.Character < other.Character
+}
+
+// NewRange converts an SCIP range into `Range`
+//
+// Pre-condition: The input slice must follow the SCIP range encoding.
+// https://sourcegraph.com/github.com/sourcegraph/scip/-/blob/scip.proto?L646:18-646:23
+func NewRange(scipRange []int32) Range {
+	// Single-line case is most common
+	endCharacter := scipRange[2]
+	endLine := scipRange[0]
+	if len(scipRange) == 4 { // multi-line
+		endCharacter = scipRange[3]
+		endLine = scipRange[2]
+	}
+	return Range{
 		Start: Position{
 			Line:      scipRange[0],
 			Character: scipRange[1],
@@ -48,4 +78,58 @@ func (r Range) SCIPRange() []int32 {
 		return []int32{r.Start.Line, r.Start.Character, r.End.Character}
 	}
 	return []int32{r.Start.Line, r.Start.Character, r.End.Line, r.End.Character}
+}
+
+// Contains checks if position is within the range
+func (r Range) Contains(position Position) bool {
+	return !position.Less(r.Start) && position.Less(r.End)
+}
+
+// Intersects checks if two ranges intersect.
+//
+// case 1: r1.Start >= other.Start && r1.Start < other.End
+// case 2: r2.Start >= r1.Start && r2.Start < r1.End
+func (r Range) Intersects(other Range) bool {
+	return r.Start.Less(other.End) && other.Start.Less(r.End)
+}
+
+// Compare compares two ranges.
+//
+// Returns 0 if the ranges intersect (not just if they're equal).
+func (r Range) Compare(other Range) int {
+	if r.Intersects(other) {
+		return 0
+	}
+	return r.Start.Compare(other.Start)
+}
+
+// Less compares two ranges, consistent with Compare.
+//
+// r.Compare(other) < 0 iff r.Less(other).
+func (r Range) Less(other Range) bool {
+	return r.End.Compare(other.Start) <= 0
+}
+
+// CompareStrict compares two ranges.
+//
+// Returns 0 iff the ranges are exactly equal.
+func (r Range) CompareStrict(other Range) int {
+	if ret := r.Start.Compare(other.Start); ret != 0 {
+		return ret
+	}
+	return r.End.Compare(other.End)
+}
+
+// LessStrict compares two ranges, consistent with CompareStrict.
+//
+// r.CompareStrict(other) < 0 iff r.LessStrict(other).
+func (r Range) LessStrict(other Range) bool {
+	if ret := r.Start.Compare(other.Start); ret != 0 {
+		return ret < 0
+	}
+	return r.End.Less(other.End)
+}
+
+func (r Range) String() string {
+	return fmt.Sprintf("%d:%d-%d:%d", r.Start.Line, r.Start.Character, r.End.Line, r.End.Character)
 }

--- a/bindings/go/scip/position_test.go
+++ b/bindings/go/scip/position_test.go
@@ -1,0 +1,156 @@
+package scip
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// TODO: Replace with cmp.Compare go 1.21 or newer.
+func compare(i1 int, i2 int) int {
+	if i1 < i2 {
+		return -1
+	}
+	if i1 > i2 {
+		return 1
+	}
+	return 0
+}
+
+func TestUnitComparePosition(t *testing.T) {
+	positions := []Position{
+		{0, 0},
+		{0, 1},
+		{1, 0},
+		{1, 1},
+		{1, 2},
+		{2, 1},
+		{2, 2},
+	}
+
+	type testCase struct {
+		p1       Position
+		p2       Position
+		expected int
+	}
+
+	testCases := make([]testCase, len(positions)*len(positions))
+
+	// There is a total ordering on these positions, so we just test all possible combinations
+	for i1, pos1 := range positions {
+		for i2, pos2 := range positions {
+			testCases = append(testCases, testCase{pos1, pos2, compare(i1, i2)})
+		}
+	}
+
+	for _, testCase := range testCases {
+		if actual := testCase.p1.Compare(testCase.p2); actual != testCase.expected {
+			t.Errorf("unexpected result. %+v.Compare(%+v) want=%d have=%d", testCase.p1, testCase.p2, testCase.expected, actual)
+		}
+	}
+}
+
+func TestUnitIntersect(t *testing.T) {
+	r1 := Range{Position{0, 0}, Position{0, 10}}
+	r2 := Range{Position{0, 5}, Position{1, 5}}
+	r3 := Range{Position{1, 0}, Position{1, 10}}
+
+	require.Truef(t, r1.Intersects(r2), "%+v.Intersects(%+v)", r1, r2)
+	require.Truef(t, r2.Intersects(r3), "%+v.Intersects(%+v)", r2, r3)
+	require.Falsef(t, r1.Intersects(r3), "%+v.Intersects(%+v)", r1, r3)
+}
+
+func genPosition() *rapid.Generator[Position] {
+	return rapid.Custom(func(t *rapid.T) Position {
+		return Position{
+			Line:      rapid.Int32Range(0, 10).Draw(t, "Line"),
+			Character: rapid.Int32Range(0, 10).Draw(t, "Character"),
+		}
+	})
+}
+
+func genRange() *rapid.Generator[Range] {
+	return rapid.Custom(func(t *rapid.T) Range {
+		posGen := genPosition()
+		start := posGen.Draw(t, "start")
+		end := posGen.Draw(t, "end")
+		// A well formed range is always start <= end.
+		if start.Compare(end) > 0 {
+			start, end = end, start
+		}
+		return Range{
+			Start: start,
+			End:   end,
+		}
+	})
+}
+
+func TestComparePositionTransitive(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		p1 := genPosition().Draw(t, "p1")
+		p2 := genPosition().Draw(t, "p2")
+		p3 := genPosition().Draw(t, "p3")
+
+		if p1.Compare(p2) < 0 && p2.Compare(p3) < 0 {
+			if !(p1.Compare(p3) < 0) {
+				t.Errorf("%+v < %+v < %+v but !(%+v < %+v)", p1, p2, p3, p1, p3)
+			}
+		}
+	})
+}
+
+func TestIntersects(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		r1 := genRange().Draw(t, "r1")
+		r2 := genRange().Draw(t, "r2")
+
+		if r1.Intersects(r2) {
+			if !(r1.Contains(r2.Start) || r2.Contains(r1.Start)) {
+				t.Errorf("%+v overlaps with %+v but neither contains the others start position", r1, r2)
+			}
+		}
+	})
+}
+
+func TestLessCompareConsistent(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		r1 := genRange().Draw(t, "r1")
+		r2 := genRange().Draw(t, "r2")
+		if r1.Compare(r2) < 0 {
+			if !(r1.Less(r2)) {
+				t.Errorf("%+v.Compare(%+v) < 0 but !(%+v < %+v)", r1, r2, r1, r2)
+			}
+		} else {
+			if r1.Less(r2) {
+				t.Errorf("%+v.Compare(%+v) >= 0 but  (%+v < %+v)", r1, r2, r1, r2)
+			}
+		}
+	})
+
+	rapid.Check(t, func(t *rapid.T) {
+		r1 := genRange().Draw(t, "r1")
+		r2 := genRange().Draw(t, "r2")
+		if r1.CompareStrict(r2) < 0 {
+			if !(r1.LessStrict(r2)) {
+				t.Errorf("%+v.CompareStrict(%+v) < 0 but !(%+v < %+v)", r1, r2, r1, r2)
+			}
+		} else {
+			if r1.LessStrict(r2) {
+				t.Errorf("%+v.CompareStrict(%+v) >= 0 but  (%+v < %+v)", r1, r2, r1, r2)
+			}
+		}
+	})
+}
+
+func TestCompareReverse(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		r1 := genRange().Draw(t, "r1")
+		r2 := genRange().Draw(t, "r2")
+		cmp1 := r1.Compare(r2)
+		cmp2 := r2.Compare(r1)
+		if cmp1 != -cmp2 {
+			t.Errorf("%+v.Compare(%+v) = %d but %+v.Compare(%+v) = %d", r1, r2, cmp1, r2, r1, cmp2)
+		}
+	})
+}

--- a/bindings/go/scip/sort.go
+++ b/bindings/go/scip/sort.go
@@ -31,15 +31,16 @@ func SortDocuments(documents []*Document) []*Document {
 // occurrences are properly enclosed by later occurrences.
 func FindOccurrences(occurrences []*Occurrence, targetLine, targetCharacter int32) []*Occurrence {
 	var filtered []*Occurrence
+	pos := Position{targetLine, targetCharacter}
 	for _, occurrence := range occurrences {
-		if compareRanges(occurrence.Range, targetLine, targetCharacter) == 0 {
+		if NewRange(occurrence.Range).Contains(pos) {
 			filtered = append(filtered, occurrence)
 		}
 	}
 
 	sort.Slice(filtered, func(i, j int) bool {
-		// Ordered so that the least precise (largest) range comes first
-		return compareRanges(filtered[i].Range, filtered[j].Range...) > 0
+		// Ordered so that the least precise (largest) range comes last
+		return NewRange(filtered[i].Range).CompareStrict(NewRange(filtered[j].Range)) > 0
 	})
 
 	return filtered
@@ -51,11 +52,12 @@ func FindOccurrences(occurrences []*Occurrence, targetLine, targetCharacter int3
 // occurrences are sorted by symbol name.
 func SortOccurrences(occurrences []*Occurrence) []*Occurrence {
 	sort.Slice(occurrences, func(i, j int) bool {
-		if rawRangesEqual(occurrences[i].Range, occurrences[j].Range) {
-			return occurrences[i].Symbol < occurrences[j].Symbol
+		r1 := NewRange(occurrences[i].Range)
+		r2 := NewRange(occurrences[j].Range)
+		if ret := r1.CompareStrict(r2); ret != 0 {
+			return ret < 0
 		}
-
-		return compareRanges(occurrences[i].Range, occurrences[j].Range...) <= 0
+		return occurrences[i].Symbol < occurrences[j].Symbol
 	})
 
 	return occurrences
@@ -81,18 +83,10 @@ func rawRangesEqual(a, b []int32) bool {
 
 // SortRanges sorts the given range slice (in-place) and returns it (for convenience). Ranges are
 // sorted in ascending order of starting position, where enclosing ranges come before the enclosed.
-func SortRanges(ranges []*Range) []*Range {
+func SortRanges(ranges []Range) []Range {
 	sort.Slice(ranges, func(i, j int) bool {
-		return comparePositionToRange(
-			ranges[i].Start.Line,
-			ranges[i].Start.Character,
-			ranges[i].End.Line,
-			ranges[i].End.Character,
-			ranges[j].Start.Line,
-			ranges[j].Start.Character,
-		) <= 0
+		return ranges[i].LessStrict(ranges[j])
 	})
-
 	return ranges
 }
 
@@ -139,39 +133,6 @@ func SortRelationships(relationships []*Relationship) []*Relationship {
 	})
 
 	return relationships
-}
-
-// compareRanges compares the order of the leading edge of the two ranges. This method returns
-//
-// - -1 if the leading edge of r2 occurs before r1,
-// - +1 if the leading edge of r2 occurs after r1, and
-// - +0 if the leading edge of r2 is enclosed by r1.
-//
-// Note that ranges are half-closed intervals, so a match on the leading end of the range will
-// be considered enclosed, but a match on the trailing edge will not.
-func compareRanges(r1 []int32, r2 ...int32) int {
-	startLine, startCharacter, endLine, endCharacter := unpackRange(r1)
-
-	return comparePositionToRange(
-		startLine,
-		startCharacter,
-		endLine,
-		endCharacter,
-		r2[0],
-		r2[1],
-	)
-}
-
-// unpackRange unpacks the raw SCIP range into a four-element range bound. This function
-// duplicates some of the logic in the SCIP repository, but we're dealing heavily with raw
-// encoded proto messages in the database layer here as well, and we'd like to avoid boxing
-// into a Range unnecessarily.
-func unpackRange(r []int32) (int32, int32, int32, int32) {
-	if len(r) == 3 {
-		return r[0], r[1], r[0], r[2]
-	}
-
-	return r[0], r[1], r[2], r[3]
 }
 
 // comparePositionToRange compares the given target position represented by line and character

--- a/bindings/go/scip/sort.go
+++ b/bindings/go/scip/sort.go
@@ -33,14 +33,14 @@ func FindOccurrences(occurrences []*Occurrence, targetLine, targetCharacter int3
 	var filtered []*Occurrence
 	pos := Position{targetLine, targetCharacter}
 	for _, occurrence := range occurrences {
-		if NewRange(occurrence.Range).Contains(pos) {
+		if NewRangeUnchecked(occurrence.Range).Contains(pos) {
 			filtered = append(filtered, occurrence)
 		}
 	}
 
 	sort.Slice(filtered, func(i, j int) bool {
 		// Ordered so that the least precise (largest) range comes last
-		return NewRange(filtered[i].Range).CompareStrict(NewRange(filtered[j].Range)) > 0
+		return NewRangeUnchecked(filtered[i].Range).CompareStrict(NewRangeUnchecked(filtered[j].Range)) > 0
 	})
 
 	return filtered
@@ -52,8 +52,8 @@ func FindOccurrences(occurrences []*Occurrence, targetLine, targetCharacter int3
 // occurrences are sorted by symbol name.
 func SortOccurrences(occurrences []*Occurrence) []*Occurrence {
 	sort.Slice(occurrences, func(i, j int) bool {
-		r1 := NewRange(occurrences[i].Range)
-		r2 := NewRange(occurrences[j].Range)
+		r1 := NewRangeUnchecked(occurrences[i].Range)
+		r2 := NewRangeUnchecked(occurrences[j].Range)
 		if ret := r1.CompareStrict(r2); ret != 0 {
 			return ret < 0
 		}
@@ -75,8 +75,8 @@ func rawRangesEqual(a, b []int32) bool {
 		return true
 	}
 
-	ra := NewRange(a)
-	rb := NewRange(b)
+	ra := NewRangeUnchecked(a)
+	rb := NewRangeUnchecked(b)
 
 	return ra.Start.Line == rb.Start.Line && ra.Start.Character == rb.Start.Character && ra.End.Line == rb.End.Line && ra.End.Character == rb.End.Character
 }

--- a/bindings/go/scip/sort_test.go
+++ b/bindings/go/scip/sort_test.go
@@ -77,7 +77,7 @@ func TestSortOccurrences(t *testing.T) {
 }
 
 func TestSortRanges(t *testing.T) {
-	occurrences := []*Range{
+	occurrences := []Range{
 		NewRange([]int32{2, 3, 5}),       // rank 2
 		NewRange([]int32{11, 10, 12}),    // rank 10
 		NewRange([]int32{6, 3, 5}),       // rank 4
@@ -93,7 +93,7 @@ func TestSortRanges(t *testing.T) {
 		NewRange([]int32{12, 4, 13, 8}),  // rank 12
 		NewRange([]int32{1, 3, 3, 5}),    // rank 1
 	}
-	unsorted := make([]*Range, len(occurrences))
+	unsorted := make([]Range, len(occurrences))
 	copy(unsorted, occurrences)
 
 	ranges := [][]int32{}
@@ -120,27 +120,5 @@ func TestSortRanges(t *testing.T) {
 	}
 	if diff := cmp.Diff(expected, ranges); diff != "" {
 		t.Errorf("unexpected occurrence order (-want +got):\n%s", diff)
-	}
-}
-
-func TestComparePositionToRange(t *testing.T) {
-	testCases := []struct {
-		line      int32
-		character int32
-		expected  int
-	}{
-		{5, 11, 0},
-		{5, 12, 0},
-		{5, 13, -1},
-		{4, 12, +1},
-		{5, 10, +1},
-		{5, 14, -1},
-		{6, 12, -1},
-	}
-
-	for _, testCase := range testCases {
-		if cmpRes := comparePositionToRange(5, 11, 5, 13, testCase.line, testCase.character); cmpRes != testCase.expected {
-			t.Errorf("unexpected ComparePositionSCIP result for %d:%d. want=%d have=%d", testCase.line, testCase.character, testCase.expected, cmpRes)
-		}
 	}
 }

--- a/bindings/go/scip/sort_test.go
+++ b/bindings/go/scip/sort_test.go
@@ -78,20 +78,20 @@ func TestSortOccurrences(t *testing.T) {
 
 func TestSortRanges(t *testing.T) {
 	occurrences := []Range{
-		NewRange([]int32{2, 3, 5}),       // rank 2
-		NewRange([]int32{11, 10, 12}),    // rank 10
-		NewRange([]int32{6, 3, 5}),       // rank 4
-		NewRange([]int32{10, 4, 8}),      // rank 6
-		NewRange([]int32{10, 10, 12}),    // rank 7
-		NewRange([]int32{0, 3, 4, 5}),    // rank 0
-		NewRange([]int32{12, 1, 13, 12}), // rank 11
-		NewRange([]int32{11, 1, 3}),      // rank 8
-		NewRange([]int32{5, 3, 5}),       // rank 3
-		NewRange([]int32{10, 1, 3}),      // rank 5
-		NewRange([]int32{12, 10, 13, 3}), // rank 13
-		NewRange([]int32{11, 4, 8}),      // rank 9
-		NewRange([]int32{12, 4, 13, 8}),  // rank 12
-		NewRange([]int32{1, 3, 3, 5}),    // rank 1
+		NewRangeUnchecked([]int32{2, 3, 5}),       // rank 2
+		NewRangeUnchecked([]int32{11, 10, 12}),    // rank 10
+		NewRangeUnchecked([]int32{6, 3, 5}),       // rank 4
+		NewRangeUnchecked([]int32{10, 4, 8}),      // rank 6
+		NewRangeUnchecked([]int32{10, 10, 12}),    // rank 7
+		NewRangeUnchecked([]int32{0, 3, 4, 5}),    // rank 0
+		NewRangeUnchecked([]int32{12, 1, 13, 12}), // rank 11
+		NewRangeUnchecked([]int32{11, 1, 3}),      // rank 8
+		NewRangeUnchecked([]int32{5, 3, 5}),       // rank 3
+		NewRangeUnchecked([]int32{10, 1, 3}),      // rank 5
+		NewRangeUnchecked([]int32{12, 10, 13, 3}), // rank 13
+		NewRangeUnchecked([]int32{11, 4, 8}),      // rank 9
+		NewRangeUnchecked([]int32{12, 4, 13, 8}),  // rank 12
+		NewRangeUnchecked([]int32{1, 3, 3, 5}),    // rank 1
 	}
 	unsorted := make([]Range, len(occurrences))
 	copy(unsorted, occurrences)

--- a/bindings/go/scip/testutil/format.go
+++ b/bindings/go/scip/testutil/format.go
@@ -94,7 +94,7 @@ func FormatSnapshot(
 		b.WriteString("\n")
 		for i < len(document.Occurrences) && document.Occurrences[i].Range[0] == int32(lineNumber) {
 			occ := document.Occurrences[i]
-			pos := scip.NewRange(occ.Range)
+			pos := scip.NewRangeUnchecked(occ.Range)
 			if !pos.IsSingleLine() {
 				i++
 				continue

--- a/cmd/scip/lint.go
+++ b/cmd/scip/lint.go
@@ -113,7 +113,7 @@ type occurrenceKey struct {
 }
 
 func scipOccurrenceKey(occ *scip.Occurrence) occurrenceKey {
-	return occurrenceKey{scip.NewRange(occ.Range), occ.SymbolRoles}
+	return occurrenceKey{scip.NewRangeUnchecked(occ.Range), occ.SymbolRoles}
 }
 
 type occurrenceMap = map[occurrenceKey]*scip.Occurrence
@@ -202,16 +202,16 @@ func (st *symbolTable) addRelationship(sym string, path string, rel *scip.Relati
 
 func (st *symbolTable) addOccurrence(path string, occ *scip.Occurrence) error {
 	if occ.Symbol == "" {
-		return emptyStringError{what: "symbol", context: fmt.Sprintf("occurrence at %s @ %s", path, scipRangeToString(scip.NewRange(occ.Range)))}
+		return emptyStringError{what: "symbol", context: fmt.Sprintf("occurrence at %s @ %s", path, scipRangeToString(scip.NewRangeUnchecked(occ.Range)))}
 	}
 	if scip.SymbolRole_Definition.Matches(occ) && scip.SymbolRole_ForwardDefinition.Matches(occ) {
-		return forwardDefIsDefinitionError{occ.Symbol, path, scip.NewRange(occ.Range)}
+		return forwardDefIsDefinitionError{occ.Symbol, path, scip.NewRangeUnchecked(occ.Range)}
 	}
 	tryInsertOccurrence := func(occMap fileOccurrenceMap) error {
 		occKey := scipOccurrenceKey(occ)
 		if fileOccs, ok := occMap[path]; ok {
 			if _, ok := fileOccs[occKey]; ok {
-				return duplicateOccurrenceWarning{occ.Symbol, path, scip.NewRange(occ.Range), occ.SymbolRoles}
+				return duplicateOccurrenceWarning{occ.Symbol, path, scip.NewRangeUnchecked(occ.Range), occ.SymbolRoles}
 			} else {
 				fileOccs[occKey] = occ
 			}
@@ -231,7 +231,7 @@ func (st *symbolTable) addOccurrence(path string, occ *scip.Occurrence) error {
 			return err
 		}
 	} else {
-		return missingSymbolForOccurrenceError{occ.Symbol, path, scip.NewRange(occ.Range)}
+		return missingSymbolForOccurrenceError{occ.Symbol, path, scip.NewRangeUnchecked(occ.Range)}
 	}
 	return nil
 }

--- a/cmd/scip/lint.go
+++ b/cmd/scip/lint.go
@@ -113,7 +113,7 @@ type occurrenceKey struct {
 }
 
 func scipOccurrenceKey(occ *scip.Occurrence) occurrenceKey {
-	return occurrenceKey{*scip.NewRange(occ.Range), occ.SymbolRoles}
+	return occurrenceKey{scip.NewRange(occ.Range), occ.SymbolRoles}
 }
 
 type occurrenceMap = map[occurrenceKey]*scip.Occurrence
@@ -202,16 +202,16 @@ func (st *symbolTable) addRelationship(sym string, path string, rel *scip.Relati
 
 func (st *symbolTable) addOccurrence(path string, occ *scip.Occurrence) error {
 	if occ.Symbol == "" {
-		return emptyStringError{what: "symbol", context: fmt.Sprintf("occurrence at %s @ %s", path, scipRangeToString(*scip.NewRange(occ.Range)))}
+		return emptyStringError{what: "symbol", context: fmt.Sprintf("occurrence at %s @ %s", path, scipRangeToString(scip.NewRange(occ.Range)))}
 	}
 	if scip.SymbolRole_Definition.Matches(occ) && scip.SymbolRole_ForwardDefinition.Matches(occ) {
-		return forwardDefIsDefinitionError{occ.Symbol, path, *scip.NewRange(occ.Range)}
+		return forwardDefIsDefinitionError{occ.Symbol, path, scip.NewRange(occ.Range)}
 	}
 	tryInsertOccurrence := func(occMap fileOccurrenceMap) error {
 		occKey := scipOccurrenceKey(occ)
 		if fileOccs, ok := occMap[path]; ok {
 			if _, ok := fileOccs[occKey]; ok {
-				return duplicateOccurrenceWarning{occ.Symbol, path, *scip.NewRange(occ.Range), occ.SymbolRoles}
+				return duplicateOccurrenceWarning{occ.Symbol, path, scip.NewRange(occ.Range), occ.SymbolRoles}
 			} else {
 				fileOccs[occKey] = occ
 			}
@@ -231,7 +231,7 @@ func (st *symbolTable) addOccurrence(path string, occ *scip.Occurrence) error {
 			return err
 		}
 	} else {
-		return missingSymbolForOccurrenceError{occ.Symbol, path, *scip.NewRange(occ.Range)}
+		return missingSymbolForOccurrenceError{occ.Symbol, path, scip.NewRange(occ.Range)}
 	}
 	return nil
 }

--- a/cmd/scip/lint_test.go
+++ b/cmd/scip/lint_test.go
@@ -167,15 +167,15 @@ func TestErrors(t *testing.T) {
 			"missingSymbolForOccurrence",
 			makeIndex(nil, nil, stringMap{"f": {"a"}}),
 			[]error{
-				missingSymbolForOccurrenceError{"a", "f", *scip.NewRange(placeholderRange)},
+				missingSymbolForOccurrenceError{"a", "f", scip.NewRange(placeholderRange)},
 			},
 		},
 		{
 			"duplicateOccurrence",
 			makeIndex([]string{"a"}, stringMap{"f": {"b"}}, stringMap{"f": {"a", "a", "b", "b"}}),
 			[]error{
-				duplicateOccurrenceWarning{"a", "f", *scip.NewRange(placeholderRange), placeholderRole},
-				duplicateOccurrenceWarning{"b", "f", *scip.NewRange(placeholderRange), placeholderRole},
+				duplicateOccurrenceWarning{"a", "f", scip.NewRange(placeholderRange), placeholderRole},
+				duplicateOccurrenceWarning{"b", "f", scip.NewRange(placeholderRange), placeholderRole},
 			},
 		},
 	}

--- a/cmd/scip/lint_test.go
+++ b/cmd/scip/lint_test.go
@@ -167,15 +167,15 @@ func TestErrors(t *testing.T) {
 			"missingSymbolForOccurrence",
 			makeIndex(nil, nil, stringMap{"f": {"a"}}),
 			[]error{
-				missingSymbolForOccurrenceError{"a", "f", scip.NewRange(placeholderRange)},
+				missingSymbolForOccurrenceError{"a", "f", scip.NewRangeUnchecked(placeholderRange)},
 			},
 		},
 		{
 			"duplicateOccurrence",
 			makeIndex([]string{"a"}, stringMap{"f": {"b"}}, stringMap{"f": {"a", "a", "b", "b"}}),
 			[]error{
-				duplicateOccurrenceWarning{"a", "f", scip.NewRange(placeholderRange), placeholderRole},
-				duplicateOccurrenceWarning{"b", "f", scip.NewRange(placeholderRange), placeholderRole},
+				duplicateOccurrenceWarning{"a", "f", scip.NewRangeUnchecked(placeholderRange), placeholderRole},
+				duplicateOccurrenceWarning{"b", "f", scip.NewRangeUnchecked(placeholderRange), placeholderRole},
 			},
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/urfave/cli/v2 v2.25.7
 	golang.org/x/tools v0.12.0
 	google.golang.org/protobuf v1.31.0
+	pgregory.net/rapid v1.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -660,3 +660,5 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 mvdan.cc/gofumpt v0.4.0/go.mod h1:PljLOHDeZqgS8opHRKLzp2It2VBuSdteAgqUfzMTxlQ=
 mvdan.cc/gofumpt v0.5.0 h1:0EQ+Z56k8tXjj/6TQD25BFNKQXpCvT0rnansIc7Ug5E=
 mvdan.cc/gofumpt v0.5.0/go.mod h1:HBeVDtMKRZpXyxFciAirzdKklDlGu8aAy1wEbH5Y9js=
+pgregory.net/rapid v1.1.0 h1:CMa0sjHSru3puNx+J0MIAuiiEV4N0qj8/cMWGBBCsjw=
+pgregory.net/rapid v1.1.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=


### PR DESCRIPTION
The Range type in this package is 128-bits, whereas some Range types
in the Sourcegraph packages are 256-bits. Additionally, some of the APIs
would previously work using `*Range` instead of just `Range`.

This PR fixes the pointer-based APIs and adds commonly used APIs
for Range and Position so we don't have to keep re-implementing them.

We also add documentation that ranges are half-open, not closed.

### Test plan

Added new tests
