### PR TITLE
codegen: Pass --installdir flag to cabal install

### DIFF
--- a/dev/proto-generate.sh
+++ b/dev/proto-generate.sh
@@ -19,8 +19,9 @@ fi
 
 echo "--- Haskell ---"
 command -v cabal > /dev/null 2>&1 || { echo >&2 "Haskell's 'cabal' command is not installed. Please install it first via https://www.haskell.org/ghcup/"; exit 1; }
-cabal install proto-lens-protoc-0.7.1.1 ghc-source-gen-0.4.3.0 --overwrite-policy=always --ghc-options='-j2 +RTS -A32m'
-ln -sfv `which proto-lens-protoc` "$PWD/.bin/protoc-gen-haskell"
+cabal install proto-lens-protoc-0.7.1.1 ghc-source-gen-0.4.3.0 --overwrite-policy=always --ghc-options='-j2 +RTS -A32m' --installdir="$PWD/.bin"
+# buf requires the generator to be named protoc-gen-*
+ln -sfv "$PWD/.bin/proto-lens-protoc" "$PWD/.bin/protoc-gen-haskell"
 PATH="$PWD/.bin:$PATH"
 
 echo "--- buf ---"


### PR DESCRIPTION
In some configurations, 'cabal install' will install the binary
into the current directory instead of in the global directory
on 'PATH', which can cause the haskell step to fail. Pass
the --installdir flag to avoid that.

### Test plan

Covered by existing codegen