### PR TITLE
ci: Fix workflow breakage on version bump

### DIFF
--- a/.github/workflows/build-env-docker.yml
+++ b/.github/workflows/build-env-docker.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests
+          name: digests-${{ matrix.runs-on }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -108,7 +108,8 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          name: digests
+          pattern: digests-*
+          merge-multiple: true
           path: /tmp/digests
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
I incorrectly missed the fact that we actually did have a matrix
build when reviewing https://github.com/sourcegraph/scip/pull/272

### Test plan

Let's see if this PR fixes the job after merging into main