### PR TITLE
Resolved formatting issues in test command output

### DIFF
--- a/cmd/scip/main_test.go
+++ b/cmd/scip/main_test.go
@@ -134,38 +134,38 @@ func TestSCIPTests(t *testing.T) {
 		{"roles",
 			autogold.Expect("✓ passes.repro (3 assertions)\n"),
 			autogold.Expect(`✗ fails-wrong-role.repro
-    Failure - row: 0, column: 13
+    Failure [Ln: 1, Col: 13]
       Expected: 'reference reprolang repro_manager roles 1.0.0 fails-wrong-role.repro/hello().'
-      Actual:
-        - 'definition reprolang repro_manager roles 1.0.0 fails-wrong-role.repro/hello().'✗ fails-wrong-symbol.repro
-    Failure - row: 0, column: 13
+      Actual:   'definition reprolang repro_manager roles 1.0.0 fails-wrong-role.repro/hello().'
+✗ fails-wrong-symbol.repro
+    Failure [Ln: 1, Col: 13]
       Expected: 'definition reprolang repro_manager roles 1.0.0 fails-wrong-role.repro/hello2().'
-      Actual:
-        - 'definition reprolang repro_manager roles 1.0.0 fails-wrong-symbol.repro/hello().'`),
+      Actual:   'definition reprolang repro_manager roles 1.0.0 fails-wrong-symbol.repro/hello().'
+`),
 		},
 		{"ranges",
 			autogold.Expect("✓ passes.repro (3 assertions)\n"),
 			autogold.Expect(`✗ fails.repro
-    Failure - row: 0, column: 10
+    Failure [Ln: 1, Col: 10]
       Expected: 'definition passes.repro/hello().'
-      Actual:
-        - No attributes found`),
+        Actual: <no attributes found>
+`),
 		},
 		{"diagnostics",
 			autogold.Expect("✓ passes.repro (2 assertions)\n"),
 			autogold.Expect(`✗ fails-incorrect-diagnostic.repro
-    Failure - row: 0, column: 11
+    Failure [Ln: 1, Col: 11]
       Expected: 'diagnostic Warning:'
                 'THIS IS NOT CORRECT'
-      Actual:
-        - 'definition reprolang repro_manager diagnostics 1.0.0 fails-incorrect-diagnostic.repro/deprecatedMethod.'
-        - 'diagnostic Warning'
-          'deprecated identifier'✗ fails-no-diagnostic.repro
-    Failure - row: 0, column: 11
+      Actual: * 'definition reprolang repro_manager diagnostics 1.0.0 fails-incorrect-diagnostic.repro/deprecatedMethod.'
+              * 'diagnostic Warning'
+                'deprecated identifier'
+✗ fails-no-diagnostic.repro
+    Failure [Ln: 1, Col: 11]
       Expected: 'diagnostic Warning:'
                 'deprecated identifier'
-      Actual:
-        - 'definition reprolang repro_manager diagnostics 1.0.0 fails-no-diagnostic.repro/hello().'`),
+      Actual:   'definition reprolang repro_manager diagnostics 1.0.0 fails-no-diagnostic.repro/hello().'
+`),
 		},
 	}
 

--- a/cmd/scip/test.go
+++ b/cmd/scip/test.go
@@ -142,7 +142,7 @@ func testMain(
 			red.Fprintf(output, "✗ %s\n", document.RelativePath)
 
 			for _, failure := range failures {
-				fmt.Fprintf(output, indent(failure, 4))
+				fmt.Fprintf(output, indent(failure, 4)+"\n")
 			}
 		} else {
 			green := color.New(color.FgGreen)
@@ -421,21 +421,31 @@ func (s symbolAttributeTestCase) check(attr symbolAttribute) bool {
 
 func formatFailure(lineNumber int, testCase symbolAttributeTestCase, attributesAtLine []symbolAttribute) string {
 	failureDesc := []string{
-		fmt.Sprintf("Failure - row: %d, column: %d", lineNumber, testCase.attribute.start),
+		fmt.Sprintf("Failure [Ln: %d, Col: %d]", lineNumber+1, testCase.attribute.start),
 		fmt.Sprintf("  Expected: '%s %s'", testCase.attribute.kind, testCase.attribute.data),
 	}
 	for _, add := range testCase.attribute.additionalData {
 		failureDesc = append(failureDesc, indent(fmt.Sprintf("'%s'", add), 12))
 	}
 
-	failureDesc = append(failureDesc, "  Actual:")
 	if (len(attributesAtLine)) == 0 {
-		failureDesc = append(failureDesc, "    - No attributes found")
+		failureDesc = append(failureDesc, "    Actual: <No attributes found>")
 	} else {
-		for _, attr := range attributesAtLine {
-			failureDesc = append(failureDesc, fmt.Sprintf("    - '%s %s'", attr.kind, attr.data))
+		for i, attr := range attributesAtLine {
+			prefix := "       "
+			if i == 0 {
+				prefix = "Actual:"
+			}
+
+			if len(attributesAtLine) > 1 {
+				prefix += " *"
+			} else {
+				prefix += "  "
+			}
+
+			failureDesc = append(failureDesc, fmt.Sprintf("  %s '%s %s'", prefix, attr.kind, attr.data))
 			for _, add := range attr.additionalData {
-				failureDesc = append(failureDesc, indent(fmt.Sprintf("'%s'", add), 6))
+				failureDesc = append(failureDesc, indent(fmt.Sprintf("'%s'", add), 12))
 			}
 		}
 	}

--- a/cmd/scip/test.go
+++ b/cmd/scip/test.go
@@ -429,7 +429,7 @@ func formatFailure(lineNumber int, testCase symbolAttributeTestCase, attributesA
 	}
 
 	if (len(attributesAtLine)) == 0 {
-		failureDesc = append(failureDesc, "    Actual: <No attributes found>")
+		failureDesc = append(failureDesc, "    Actual: <no attributes found>")
 	} else {
 		for i, attr := range attributesAtLine {
 			prefix := "       "


### PR DESCRIPTION
The new `test` command introduced in [this PR](https://github.com/sourcegraph/scip/pull/236) contained some issues when rendering the failure list.

Upon failure, this is what the output would look like
```console
✗ lib/functions.dart
    Failure - row: 2, column: 2
      Expected: 'definition asdf'
      Actual:
        - 'reference scip-dart pub scip_dart_test 1.0.0 lib/`functions.dart`/withReturn().'
        - 'diagnostic Information'
          ''withReturn' is deprecated and shouldn't be used. a.'    Failure - row: 14, column: 2
      Expected: 'reference scip-dart pub dart:core 2.19.0 dart:core/`int.dart`/int#'
      Actual:
        - 'reference scip-dart pub dart:core 2.19.0 dart:core/`int.dart`/int#'✗ Missing documents in SCIP index
    test/.dart_tool/package_config.json
    test/pubspec.lock
    test/pubspec.yaml
```

After this change, the output now looks like this
```console
✗ lib/functions.dart
    Failure [Ln: 3, Col: 2]
      Expected: 'definition asdf'
      Actual: * 'reference scip-dart pub scip_dart_test 1.0.0 lib/`functions.dart`/withReturn().'
              * 'diagnostic Information'
                ''withReturn' is deprecated and shouldn't be used. a.'
    Failure [Ln: 15, Col: 2]
      Expected: 'reference scip-dart pub dart:core 2.19.0 dart:core/`int.dart`/int#'
      Actual:   'reference scip-dart pub dart:core 2.19.0 dart:core/`int.dart`/int#'
✗ Missing documents in SCIP index
    test/.dart_tool/package_config.json
    test/pubspec.lock
    test/pubspec.yaml
```

Notable updates being:
- The line break after the last failure in a test file has been resolved
- The Expected vs Actual lines are on the same column, making it easier to locate inconsistencies
- Mutli-result "Actual" statements are now prefixed with a `*`, to indicate they are "one of many". This also helps delineate multiline test attributes