### PR TITLE
chore: Bump Yarn and nan package versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
-golang 1.20.14
-nodejs 16.20.2
+golang     1.20.14
+nodejs     16.20.2
 shellcheck 0.7.1
-yarn 1.22.17
-rust 1.71.0
-python 3.11.9
+yarn       1.22.22
+rust       1.71.0
+python     3.11.9

--- a/cmd/scip/tests/reprolang/package.json
+++ b/cmd/scip/tests/reprolang/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "nan": "^2.15.0"
+    "nan": "^2.22.0"
   },
   "devDependencies": {
     "tree-sitter-cli": "0.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@ google-protobuf@^3.20.1:
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.20.1.tgz#1b255c2b59bcda7c399df46c65206aa3c7a0ce8b"
   integrity sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw==
 
-nan@^2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
-  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
+nan@^2.22.0:
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.0.tgz#31bc433fc33213c97bad36404bb68063de604de3"
+  integrity sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==
 
 prettier@^3.3.3:
   version "3.3.3"


### PR DESCRIPTION
The old nan version caused a prettier failure in CI.
The old Yarn version triggered a warning when running locally:

    warning Your current version of Yarn is out of date. The latest version is "1.22.22", while you're on "1.22.17".

### Test plan

CI prettier