### PR TITLE
chore: Use faster 3 way string comparison

### DIFF
--- a/bindings/go/scip/sort.go
+++ b/bindings/go/scip/sort.go
@@ -2,6 +2,7 @@ package scip
 
 import (
 	"sort"
+	"strings"
 
 	"golang.org/x/exp/slices"
 )
@@ -24,12 +25,7 @@ func FindSymbol(document *Document, symbolName string) *SymbolInformation {
 // and SymbolInformation values must be merged. This guarantee is upheld by CanonicalizeDocument.
 func FindSymbolBinarySearch(canonicalizedDocument *Document, symbolName string) *SymbolInformation {
 	i, found := slices.BinarySearchFunc(canonicalizedDocument.Symbols, symbolName, func(sym *SymbolInformation, lookup string) int {
-		if sym.Symbol < lookup {
-			return -1
-		} else if sym.Symbol == lookup {
-			return 0
-		}
-		return 1
+		return strings.Compare(sym.Symbol, lookup)
 	})
 	if found {
 		return canonicalizedDocument.Symbols[i]


### PR DESCRIPTION
This should generally be faster than manual `<`/`>`.

https://github.com/golang/go/issues/61725

### Test plan

Covered by existing tests