### PR TITLE
fix: Propagate errors when creating repro SCIP index

### DIFF
--- a/cmd/scip/lint.go
+++ b/cmd/scip/lint.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"errors"
+	stderrors "errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -21,7 +21,7 @@ func lintCommand() cli.Command {
 		Action: func(c *cli.Context) error {
 			indexPath := c.Args().Get(0)
 			if indexPath == "" {
-				return errors.New("missing argument for path to SCIP index")
+				return stderrors.New("missing argument for path to SCIP index")
 			}
 			return lintMain(indexPath)
 		},
@@ -34,7 +34,7 @@ func lintMain(indexPath string) error {
 	if err != nil {
 		return err
 	}
-	return errors.Join(lintMainPure(scipIndex).data...)
+	return stderrors.Join(lintMainPure(scipIndex).data...)
 }
 
 func lintMainPure(scipIndex *scip.Index) errorSet {

--- a/cmd/scip/tests/reprolang/bindings/go/repro/ast.go
+++ b/cmd/scip/tests/reprolang/bindings/go/repro/ast.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/errors"
 	sitter "github.com/smacker/go-tree-sitter"
 
 	"github.com/sourcegraph/scip/bindings/go/scip"
@@ -77,16 +78,17 @@ func NewRangePositionFromNode(node *sitter.Node) *scip.Range {
 	}
 }
 
-func (i *identifier) resolveSymbol(localScope *reproScope, context *reproContext) {
+func (i *identifier) resolveSymbol(localScope *reproScope, context *reproContext) error {
 	scope := context.globalScope
 	if i.isLocalSymbol() {
 		scope = localScope
 	}
 	symbol, ok := scope.names[i.value]
 	if !ok {
-		symbol = "local ERROR_UNRESOLVED_SYMBOL"
+		return errors.Newf("could not resolve local symbol %q", i.value)
 	}
 	i.symbol = symbol
+	return nil
 }
 
 func (i *identifier) isLocalSymbol() bool {

--- a/cmd/scip/tests/snapshots/input/global-workspace/hello.repro
+++ b/cmd/scip/tests/snapshots/input/global-workspace/hello.repro
@@ -1,0 +1,1 @@
+definition hello().

--- a/cmd/scip/tests/snapshots/input/local-document/local2.repro
+++ b/cmd/scip/tests/snapshots/input/local-document/local2.repro
@@ -1,2 +1,2 @@
+definition localExample
 reference localExample
-

--- a/cmd/scip/tests/snapshots/output/global-cross-repo/reference.repro
+++ b/cmd/scip/tests/snapshots/output/global-cross-repo/reference.repro
@@ -1,6 +1,6 @@
  # Reference a global symbol from another workspace.
  reference global global-workspace hello.repro/hello().
-#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference local ERROR_UNRESOLVED_SYMBOL
+#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference global-workspace hello.repro/hello().
  reference global duplicates duplicate.repro/readFileSync.
 #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference duplicates duplicate.repro/readFileSync.
  

--- a/cmd/scip/tests/snapshots/output/global-workspace/hello.repro
+++ b/cmd/scip/tests/snapshots/output/global-workspace/hello.repro
@@ -1,0 +1,4 @@
+ definition hello().
+#           ^^^^^^^^ definition hello.repro/hello().
+#           documentation
+#           > signature of hello().

--- a/cmd/scip/tests/snapshots/output/local-document/local2.repro
+++ b/cmd/scip/tests/snapshots/output/local-document/local2.repro
@@ -1,4 +1,6 @@
+ definition localExample
+#           ^^^^^^^^^^^^ definition local Example
+#           documentation
+#           > signature of localExample
  reference localExample
-#          ^^^^^^^^^^^^ reference local ERROR_UNRESOLVED_SYMBOL
- 
- 
+#          ^^^^^^^^^^^^ reference local Example


### PR DESCRIPTION
When trying to use repro with relationships, noticed that
we would incorrectly set a bad symbol name instead of
propagating the error in name resolution.

### Test plan

n/a