### PR TITLE
fix: Propagate errors when creating repro SCIP index (part 2)

### DIFF
--- a/cmd/scip/tests/reprolang/bindings/go/repro/indexer.go
+++ b/cmd/scip/tests/reprolang/bindings/go/repro/indexer.go
@@ -62,15 +62,17 @@ func Index(
 	}
 
 	// Phase 2: resolve names for definitions
+	var allErrs error
 	for _, dependency := range reproDependencies {
-		dependency.enterGlobalDefinitions(ctx)
+		if err := dependency.enterGlobalDefinitions(ctx); err != nil {
+			allErrs = errors.CombineErrors(allErrs, errors.Wrapf(err, "package: %v", dependency.Package))
+		}
 	}
 	for _, file := range reproSources {
 		file.enterDefinitions(ctx)
 	}
 
 	// Phase 3: resolve names for references
-	var allErrs error
 	for _, file := range reproSources {
 		if err := file.resolveReferences(ctx); err != nil {
 			allErrs = errors.CombineErrors(allErrs, errors.Wrapf(err, "file %q", file.Source.AbsolutePath))

--- a/cmd/scip/tests/reprolang/bindings/go/repro/namer.go
+++ b/cmd/scip/tests/reprolang/bindings/go/repro/namer.go
@@ -9,7 +9,8 @@ import (
 
 // enterGlobalDefinitions inserts the names of the global symbols that are defined in this
 // dependency into the provided global scope.
-func (d *reproDependency) enterGlobalDefinitions(context *reproContext) {
+func (d *reproDependency) enterGlobalDefinitions(context *reproContext) error {
+	var errs error
 	enter := func(file *reproSourceFile, name *identifier) {
 		if name.isLocalSymbol() {
 			return
@@ -17,6 +18,7 @@ func (d *reproDependency) enterGlobalDefinitions(context *reproContext) {
 		symbol := newGlobalSymbol(d.Package, file, name)
 		parsedSymbol, err := scip.ParseSymbol(symbol)
 		if err != nil {
+			errs = errors.CombineErrors(errs, errors.Wrapf(err, "file: %q", file.Source.AbsolutePath))
 			return
 		}
 		newName := newGlobalName(context.pkg, parsedSymbol)
@@ -30,6 +32,7 @@ func (d *reproDependency) enterGlobalDefinitions(context *reproContext) {
 			enter(file, relationship.name)
 		}
 	}
+	return errs
 }
 
 // enterDefinitions inserts the names of the definitions into the appropriate scope (local symbols go into the local scope).


### PR DESCRIPTION
When trying to enter definitions, we were incorrectly dropping symbol
parsing errors. This can lead to failures downstream when attempting
Find references on a SCIP index.

### Test plan

n/a