### PR TITLE
chore: Fix protoc-gen-rs installation error

### DIFF
--- a/dev/proto-generate.sh
+++ b/dev/proto-generate.sh
@@ -12,7 +12,7 @@ PROTOC_GEN_RUST_VERSION="$(cat bindings/rust/Cargo.toml | grep 'protobuf =' | se
 if ! grep -q "$PROTOC_GEN_RUST_VERSION" "./.bin/PROTOC_GEN_RUST_VERSION" \
    || ! test -f "./.bin/bin/protoc-gen-rs"; then
   rm -rf .bin
-  cargo install --root .bin protobuf-codegen --version 3.7.1
+  cargo install --root .bin protobuf-codegen --version 3.7.1 --locked
   echo "$PROTOC_GEN_RUST_VERSION" > "./.bin/PROTOC_GEN_RUST_VERSION"
 fi
 


### PR DESCRIPTION
I'm not 100% sure as to why --locked works given that
there is no Cargo.lock either at the root of this repo
or in the rust-protobuf repo, but it seems to fix the
installation error where a dependency 'home v0.5.11'
gets picked up which ends up requiring Rust 1.81+

I saw a failure in an unrelated PR earlier here:
https://github.com/sourcegraph/scip/actions/runs/12357387613/job/34485511480?pr=297

### Test plan

Check that CI passes