### PR TITLE
feat: Upload kubernetes/kubernetes SCIP index

### DIFF
--- a/.github/workflows/scip-examples.yaml
+++ b/.github/workflows/scip-examples.yaml
@@ -11,7 +11,6 @@ permissions:
 jobs:
   index-k8s:
     if: github.repository == 'sourcegraph/scip' # Skip running on forks
-    # runs-on: ubuntu-latest-4cores
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
@@ -26,8 +25,8 @@ jobs:
           ref: master
           fetch-depth: 1
 
-      # - name: Configure git safe.directory
-      #   run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: Configure git safe.directory
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - name: Get src-cli
         run: |


### PR DESCRIPTION
Adding only `kubernetes/kubernetes` for now, to see if this works well.

The Service Account used for SCIP index upload is named `scip-upload-service-account`. It has SCIP index upload permission and has repo permission for kubernetes/kubernetes.

### Test plan

N/A
