### PR TITLE
Fix prettier formatting GitHub action

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -4,17 +4,17 @@ on:
   pull_request:
     paths:
       - '.github/workflows/**'
-      - '**.md'
-      - '**.yml'
-      - '**.yaml'
       - '**.js'
       - '**.json'
+      - '**.md'
+      - '**.yaml'
+      - '**.yml'
       - '**.ts'
 
 jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - run: yarn install
       - run: yarn run prettier-check

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -60,7 +60,6 @@ and then converting to SCIP for transmission.
     and zstd are already very good in terms of both compression
     speed and compression ratio.[^3]
 - Support efficient code navigation by itself.
-
   - Why: Code navigation fundamentally requires some form of bidirectional
     lookup which is best served by a query engine.
 


### PR DESCRIPTION
Switched to GitHub action dedicated to running prettier formatter at a fixed version.

Changed **/*.{js,json,md,ts,yaml,yml} to **.{js,json,md,ts,yaml,yml} to ensure root-level files are also formatted, matching the on.pull_request.paths filters

Formatted files.

### Test plan

N/A
