### PR TITLE
Add serilog/serilog to SCIP index examples

### DIFF
--- a/.github/workflows/scip-examples.yaml
+++ b/.github/workflows/scip-examples.yaml
@@ -48,6 +48,9 @@ jobs:
           - repository: fmtlib/fmt
             scip_binary: scip-clang
             scip_args: ""
+          - repository: serilog/serilog
+            scip_binary: scip-dotnet
+            scip_args: "index"
 
     container: sourcegraph/${{ matrix.target.scip_binary }}:latest
     concurrency:


### PR DESCRIPTION
### Test plan
Manual run: https://github.com/sourcegraph/scip/actions/runs/17575975167