### PR TITLE
Implemented `--check-documents` flag in test subcommand

### DIFF
--- a/cmd/scip/main_test.go
+++ b/cmd/scip/main_test.go
@@ -205,12 +205,12 @@ func TestSCIPTests(t *testing.T) {
 			}
 
 			var passOutput bytes.Buffer
-			err := testMain(subtestDir, passFiles, index, "#", &passOutput)
+			err := testMain(subtestDir, passFiles, false, index, "#", &passOutput)
 			require.NoError(t, err)
 			testCase.passOutput.Equal(t, passOutput.String())
 
 			var failOutput bytes.Buffer
-			err = testMain(subtestDir, failFiles, index, "#", &failOutput)
+			err = testMain(subtestDir, failFiles, false, index, "#", &failOutput)
 			require.Error(t, err)
 			testCase.failOutput.Equal(t, failOutput.String())
 		})


### PR DESCRIPTION
As discussed in https://github.com/sourcegraph/scip/issues/283, implements the `--check-documents` flag which default, opts-out of the validation ensuring that all files in the test directory have an associated document in the SCIP index

### Test plan