### PR TITLE
Replaced serde with ripgrep

### DIFF
--- a/.github/workflows/scip-examples.yaml
+++ b/.github/workflows/scip-examples.yaml
@@ -45,7 +45,7 @@ jobs:
             # We pass gem-metadata as an easy alternative to directly
             # linking to brew/Library/Homebrew/Gemfile.lock.
             scip_args: "--gem-metadata homebrew@latest ."
-          - repository: serde-rs/serde
+          - repository: BurntSushi/ripgrep
             scip_binary: scip-rust
             scip_args: ""
           - repository: fmtlib/fmt


### PR DESCRIPTION
serde has cyclic dependencies which crashes newer versions of rust-analyzer. Since all we want here is to make sure all works as expected from SCIP perspective replacement with a different project seems to be best way going forward.

### Test plan
- CI
