### PR TITLE
Render external symbols snapshot outputs

### DIFF
--- a/bindings/go/scip/testutil/format.go
+++ b/bindings/go/scip/testutil/format.go
@@ -41,12 +41,9 @@ func FormatSnapshots(
 	for _, document := range index.Documents {
 		sourceFilePath := filepath.Join(localSourcesRoot, document.RelativePath)
 		snapshot, err := FormatSnapshot(document, commentSyntax, symbolFormatter, sourceFilePath)
-		err = symbolFormatter.OnError(err)
-		if err != nil {
+		if err = symbolFormatter.OnError(err); err != nil {
 			documentErrors = errors.Join(
-				documentErrors,
-				fmt.Errorf("%s: %w", document.RelativePath, err),
-			)
+				documentErrors, fmt.Errorf("%s: %w", document.RelativePath, err))
 		}
 		sourceFile := scip.NewSourceFile(sourceFilePath,
 			document.RelativePath,
@@ -54,14 +51,11 @@ func FormatSnapshots(
 		)
 		result = append(result, sourceFile)
 	}
-	if documentErrors != nil {
-		return nil, documentErrors
-	}
-
 	if len(index.ExternalSymbols) > 0 {
 		formatted, err := formatExternalSymbols(index.ExternalSymbols, symbolFormatter)
 		if err = symbolFormatter.OnError(err); err != nil {
-			return nil, fmt.Errorf("external_symbols: %w", err)
+			documentErrors = errors.Join(
+				documentErrors, fmt.Errorf("external_symbols: %w", err))
 		}
 		result = append(result, scip.NewSourceFile(
 			filepath.Join(localSourcesRoot, "external_symbols.txt"),
@@ -70,7 +64,7 @@ func FormatSnapshots(
 		))
 	}
 
-	return result, nil
+	return result, documentErrors
 }
 
 // FormatSnapshot renders the provided SCIP index into a pretty-printed text format

--- a/bindings/go/scip/testutil/format.go
+++ b/bindings/go/scip/testutil/format.go
@@ -59,7 +59,10 @@ func FormatSnapshots(
 	}
 
 	if len(index.ExternalSymbols) > 0 {
-		formatted := formatExternalSymbols(index.ExternalSymbols, symbolFormatter)
+		formatted, err := formatExternalSymbols(index.ExternalSymbols, symbolFormatter)
+		if err = symbolFormatter.OnError(err); err != nil {
+			return nil, fmt.Errorf("external_symbols: %w", err)
+		}
 		result = append(result, scip.NewSourceFile(
 			filepath.Join(localSourcesRoot, "external_symbols.txt"),
 			"external_symbols.txt",
@@ -188,8 +191,9 @@ func FormatSnapshot(
 
 func formatExternalSymbols(
 	symbols []*scip.SymbolInformation, formatter scip.SymbolFormatter,
-) string {
+) (string, error) {
 	var b strings.Builder
+	var formattingError error
 
 	sorted := make([]*scip.SymbolInformation, len(symbols))
 	copy(sorted, symbols)
@@ -200,6 +204,8 @@ func formatExternalSymbols(
 	formatSymbol := func(symbol string) string {
 		formatted, err := formatter.Format(symbol)
 		if err != nil {
+			formattingError = errors.Join(
+				formattingError, fmt.Errorf("%s: %w", symbol, err))
 			return symbol
 		}
 		return formatted
@@ -213,7 +219,7 @@ func formatExternalSymbols(
 		writeRelationships(&b, sym.Relationships, "\n  ", formatSymbol)
 	}
 
-	return b.String()
+	return b.String(), formattingError
 }
 
 func writeRelationships(

--- a/bindings/go/scip/testutil/format.go
+++ b/bindings/go/scip/testutil/format.go
@@ -57,6 +57,16 @@ func FormatSnapshots(
 	if documentErrors != nil {
 		return nil, documentErrors
 	}
+
+	if len(index.ExternalSymbols) > 0 {
+		formatted := formatExternalSymbols(index.ExternalSymbols, symbolFormatter)
+		result = append(result, scip.NewSourceFile(
+			filepath.Join(localSourcesRoot, "external_symbols.txt"),
+			"external_symbols.txt",
+			formatted,
+		))
+	}
+
 	return result, nil
 }
 
@@ -153,23 +163,7 @@ func FormatSnapshot(
 					writeDocumentation(&b, documentation, prefix, false)
 				}
 
-				sort.SliceStable(info.Relationships, func(i, j int) bool {
-					return info.Relationships[i].Symbol < info.Relationships[j].Symbol
-				})
-				for _, relationship := range info.Relationships {
-					b.WriteString(prefix)
-					b.WriteString("relationship ")
-					b.WriteString(formatSymbol(relationship.Symbol))
-					if relationship.IsImplementation {
-						b.WriteString(" implementation")
-					}
-					if relationship.IsReference {
-						b.WriteString(" reference")
-					}
-					if relationship.IsTypeDefinition {
-						b.WriteString(" type_definition")
-					}
-				}
+				writeRelationships(&b, info.Relationships, prefix, formatSymbol)
 			}
 
 			for _, diagnostic := range occ.Diagnostics {
@@ -190,6 +184,56 @@ func FormatSnapshot(
 		}
 	}
 	return b.String(), formattingError
+}
+
+func formatExternalSymbols(symbols []*scip.SymbolInformation, formatter scip.SymbolFormatter) string {
+	var b strings.Builder
+
+	sorted := make([]*scip.SymbolInformation, len(symbols))
+	copy(sorted, symbols)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Symbol < sorted[j].Symbol
+	})
+
+	formatSymbol := func(symbol string) string {
+		formatted, err := formatter.Format(symbol)
+		if err != nil {
+			return symbol
+		}
+		return formatted
+	}
+
+	for i, sym := range sorted {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(formatSymbol(sym.Symbol))
+		writeRelationships(&b, sym.Relationships, "\n  ", formatSymbol)
+	}
+
+	return b.String()
+}
+
+func writeRelationships(b *strings.Builder, relationships []*scip.Relationship, prefix string, formatSymbol func(string) string) {
+	sorted := make([]*scip.Relationship, len(relationships))
+	copy(sorted, relationships)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Symbol < sorted[j].Symbol
+	})
+	for _, relationship := range sorted {
+		b.WriteString(prefix)
+		b.WriteString("relationship ")
+		b.WriteString(formatSymbol(relationship.Symbol))
+		if relationship.IsImplementation {
+			b.WriteString(" implementation")
+		}
+		if relationship.IsReference {
+			b.WriteString(" reference")
+		}
+		if relationship.IsTypeDefinition {
+			b.WriteString(" type_definition")
+		}
+	}
 }
 
 func writeMultiline(b *strings.Builder, prefix string, paragraph string) {

--- a/bindings/go/scip/testutil/format.go
+++ b/bindings/go/scip/testutil/format.go
@@ -186,7 +186,9 @@ func FormatSnapshot(
 	return b.String(), formattingError
 }
 
-func formatExternalSymbols(symbols []*scip.SymbolInformation, formatter scip.SymbolFormatter) string {
+func formatExternalSymbols(
+	symbols []*scip.SymbolInformation, formatter scip.SymbolFormatter,
+) string {
 	var b strings.Builder
 
 	sorted := make([]*scip.SymbolInformation, len(symbols))
@@ -214,7 +216,12 @@ func formatExternalSymbols(symbols []*scip.SymbolInformation, formatter scip.Sym
 	return b.String()
 }
 
-func writeRelationships(b *strings.Builder, relationships []*scip.Relationship, prefix string, formatSymbol func(string) string) {
+func writeRelationships(
+	b *strings.Builder,
+	relationships []*scip.Relationship,
+	prefix string,
+	formatSymbol func(string) string,
+) {
 	sorted := make([]*scip.Relationship, len(relationships))
 	copy(sorted, relationships)
 	sort.SliceStable(sorted, func(i, j int) bool {


### PR DESCRIPTION
Produce `external_symbols.txt` from `index.external_symbols`: https://github.com/scip-code/scip/blob/739faa9b609f0a86cea2be1b1d97d923b9baf9df/scip.proto#L28-L33

Example output (https://github.com/sourcegraph/scip-go/pull/198):
```
github.com/example/dep 0.1.test `github.com/example/dep`/T#
  relationship 0.1.test `sg/pr198`/Foo# implementation
```