### PR TITLE
fix `proto-review` GitHub action

### DIFF
--- a/.github/workflows/proto-review.yaml
+++ b/.github/workflows/proto-review.yaml
@@ -5,6 +5,10 @@ on:
     paths: [scip.proto]
   pull_request_review:
 
+permissions:
+  pull-requests: write
+  statuses: write
+
 jobs:
   proto-review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Context: https://github.com/scip-code/scip/actions/runs/24260175526/job/71047225914

It seems this action requires [additional permissions](https://github.com/Automattic/action-required-review?tab=readme-ov-file#permissions-required):
> This action needs access to read pull request data, request reviewers, create status checks, and to read your organization's teams.