### PR TITLE
Drop kubernetes/kubernetes from SCIP examples

### DIFF
--- a/.github/workflows/scip-examples.yaml
+++ b/.github/workflows/scip-examples.yaml
@@ -21,9 +21,6 @@ jobs:
         # precise code navigation examples at:
         # https://github.com/sourcegraph/docs/blob/main/docs/code-search/code-navigation/precise_code_navigation.mdx#precise-navigation-examples
         target:
-          - repository: kubernetes/kubernetes
-            scip_binary: scip-go
-            scip_args: "--verbose"
           - repository: google/guava
             scip_binary: scip-java
             scip_args: "index --verbose"


### PR DESCRIPTION
This is now covered by `scip-go`: https://github.com/sourcegraph/scip-go/blob/9b1792410f3dc4f7791b28dce6f855eac939030d/.github/workflows/test.yaml#L49-L52