### PR TITLE
Sync Go workspace before recomputing vendor hashes

### DIFF
--- a/.github/workflows/update-vendor-hash.yaml
+++ b/.github/workflows/update-vendor-hash.yaml
@@ -45,10 +45,17 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.app-token.outputs.token }}
 
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
       - uses: DeterminateSystems/nix-installer-action@v22
         with:
           summarize: false
       - uses: DeterminateSystems/magic-nix-cache-action@v13
+
+      - name: Sync Go workspace
+        run: go work sync
 
       - name: Recompute vendor hashes with nix-update
         run: |
@@ -69,12 +76,11 @@ jobs:
       - name: Commit and push
         run: |
           set -euo pipefail
-          if git diff --quiet flake.nix checks.nix; then
-            echo "Vendor hashes unchanged; nothing to push."
+          if git diff --quiet; then
+            echo "No changes; nothing to push."
             exit 0
           fi
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add flake.nix checks.nix
-          git commit -m 'chore: update vendor hashes for Renovate update'
+          git commit -am 'chore: tidy Go modules and update vendor hashes'
           git push


### PR DESCRIPTION
Renovate edits a single module's `go.mod`/`go.sum` and tidies that module, but doesn't propagate the new transitive versions to other workspace members that pull it in via `replace`. The Nix build then fails on those modules with:
> "updates to go.mod needed; to update it: go mod tidy"

Solution: run `go work sync` after checkout.