### PR TITLE
Tidy each Go module instead of `go work sync`

### DIFF
--- a/.github/workflows/update-vendor-hash.yaml
+++ b/.github/workflows/update-vendor-hash.yaml
@@ -54,8 +54,14 @@ jobs:
           summarize: false
       - uses: DeterminateSystems/magic-nix-cache-action@v13
 
-      - name: Sync Go workspace
-        run: go work sync
+      - name: Tidy Go modules
+        env:
+          GOWORK: 'off'
+        run: |
+          set -euo pipefail
+          for dir in bindings/go/scip . reprolang; do
+            (cd "$dir" && go mod tidy)
+          done
 
       - name: Recompute vendor hashes with nix-update
         run: |

--- a/.github/workflows/update-vendor-hash.yaml
+++ b/.github/workflows/update-vendor-hash.yaml
@@ -45,10 +45,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
       - uses: DeterminateSystems/nix-installer-action@v22
         with:
           summarize: false
@@ -59,8 +55,9 @@ jobs:
           GOWORK: 'off'
         run: |
           set -euo pipefail
+          # https://github.com/golang/go/issues/63901
           for dir in bindings/go/scip . reprolang; do
-            (cd "$dir" && go mod tidy)
+            (cd "$dir" && nix develop --command go mod tidy)
           done
 
       - name: Recompute vendor hashes with nix-update


### PR DESCRIPTION
`go work sync` propagates require directives across workspace modules but does not add the `/go.mod h1:` checksum lines that newly-introduced transitive deps need, so the downstream Nix build still fails with:

  missing go.sum entry for go.mod file; to add it:
    go mod download <module>

Run `go mod tidy` in each module instead. Tidy `bindings/go/scip` first because root and `reprolang` pull it in via `replace`.