### PR TITLE
Publish Haskell bindings to Hackage

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,7 +104,9 @@ jobs:
           use-flakehub: "disabled"
       - name: Build sdist
         working-directory: bindings/haskell
-        run: nix develop -c cabal sdist
+        run: |
+          nix develop -c cabal check
+          nix develop -c cabal sdist
       - name: Publish to Hackage
         uses: haskell-actions/hackage-publish@v1.1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,6 +91,32 @@ jobs:
           fi
         working-directory: bindings/rust
 
+  publish-haskell-bindings:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: v${{ inputs.version }}
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          use-flakehub: "disabled"
+      - name: Publish to Hackage
+        env:
+          HACKAGE_TOKEN: ${{ secrets.HACKAGE_TOKEN }}
+        working-directory: bindings/haskell
+        run: |
+          nix develop -c cabal sdist
+          TARBALL="dist-newstyle/sdist/scip-${{ inputs.version }}.tar.gz"
+          OUTPUT=$(nix develop -c cabal upload --publish --token="$HACKAGE_TOKEN" "$TARBALL" 2>&1) && exit 0
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -qF "has already been uploaded"; then
+            echo "Hackage version already published, skipping"
+          else
+            exit 1
+          fi
+
   publish-jvm-bindings:
     needs: publish
     runs-on: ubuntu-latest
@@ -225,7 +251,7 @@ jobs:
           gh release upload "$TAG" "$ASSET.tar.gz" "$ASSET.tar.gz.sha256" --clobber
 
   finalize-release:
-    needs: [release-crate, build-go-binaries, publish-jvm-bindings, publish-npm]
+    needs: [release-crate, publish-haskell-bindings, build-go-binaries, publish-jvm-bindings, publish-npm]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,20 +102,16 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v14
         with:
           use-flakehub: "disabled"
-      - name: Publish to Hackage
-        env:
-          HACKAGE_TOKEN: ${{ secrets.HACKAGE_TOKEN }}
+      - name: Build sdist
         working-directory: bindings/haskell
-        run: |
-          nix develop -c cabal sdist
-          TARBALL="dist-newstyle/sdist/scip-${{ inputs.version }}.tar.gz"
-          OUTPUT=$(nix develop -c cabal upload --publish --token="$HACKAGE_TOKEN" "$TARBALL" 2>&1) && exit 0
-          echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -qF "has already been uploaded"; then
-            echo "Hackage version already published, skipping"
-          else
-            exit 1
-          fi
+        run: nix develop -c cabal sdist
+      - name: Publish to Hackage
+        uses: haskell-actions/hackage-publish@v1.1
+        with:
+          hackageServer: https://hackage.haskell.org
+          hackageToken: ${{ secrets.HACKAGE_TOKEN }}
+          packagesPath: bindings/haskell/dist-newstyle/sdist
+          publish: true
 
   publish-jvm-bindings:
     needs: publish

--- a/bindings/haskell/README.md
+++ b/bindings/haskell/README.md
@@ -6,7 +6,7 @@ code. This package exposes Haskell types and lenses generated from
 
 ## Usage
 
-``` haskell
+```haskell
 import Data.ProtoLens (decodeMessage)
 import qualified Data.ByteString as BS
 import qualified Proto.Scip as Scip
@@ -25,6 +25,6 @@ main = do
       ]
 ```
 
-  [SCIP]: https://github.com/scip-code/scip
-  [`scip.proto`]: https://github.com/scip-code/scip/blob/main/scip.proto
-  [`proto-lens`]: https://github.com/google/proto-lens
+[SCIP]: https://github.com/scip-code/scip
+[`scip.proto`]: https://github.com/scip-code/scip/blob/main/scip.proto
+[`proto-lens`]: https://github.com/google/proto-lens

--- a/bindings/haskell/README.md
+++ b/bindings/haskell/README.md
@@ -1,50 +1,30 @@
-[![CI](https://github.com/scip-code/scip/actions/workflows/haskell.yml/badge.svg)](https://github.com/scip-code/scip/actions/workflows/haskell.yml/badge.svg)
+# scip --- Haskell bindings for SCIP
 
-# Haskell bindings for SCIP
+[SCIP] (pronounced "skip") is a language-agnostic protocol for indexing source
+code. This package exposes Haskell types and lenses generated from
+[`scip.proto`] via [`proto-lens`].
 
-These bindings use [Google's proto-lens generator for Haskell](https://github.com/google/proto-lens).
+## Usage
 
-Building: see the following workflow file for most up to date:
-https://github.com/scip-code/scip/blob/main/.github/workflows/haskell.yml
+``` haskell
+import Data.ProtoLens (decodeMessage)
+import qualified Data.ByteString as BS
+import qualified Proto.Scip as Scip
+import           Proto.Scip_Fields (documents, occurrences, symbol)
+import           Lens.Family2 ((^.))
 
-First, get a working GHC environment:
-
-```sh
-# Linux
-GHCUPVERSION=0.1.17.4
-curl --proto '=https' --tlsv1.2 -sSf https://downloads.haskell.org/~ghcup/$GHCUPVERSION/x86_64-linux-ghcup-$GHCUPVERSION > /usr/bin/ghcup && \
-chmod +x /usr/bin/ghcup
-ghcup install ghc 8.10.7 --set
-ghcup install cabal 3.6.0.0 --set
+main :: IO ()
+main = do
+  bytes <- BS.readFile "index.scip"
+  case decodeMessage bytes :: Either String Scip.Index of
+    Left  err -> putStrLn $ "parse error: " ++ err
+    Right idx -> mapM_ print
+      [ occ ^. symbol
+      | doc <- idx ^. documents
+      , occ <- doc ^. occurrences
+      ]
 ```
 
-```sh
-# macOS
-GHCUPVERSION=0.1.17.4
-curl --proto '=https' --tlsv1.2 -sSf https://downloads.haskell.org/~ghcup/$GHCUPVERSION/x86_64-apple-darwin-ghcup-$GHCUPVERSION > /usr/local/bin/ghcup && \
-chmod +x /usr/local/bin/ghcup
-ghcup install ghc 8.10.7 --set
-ghcup install cabal 3.6.0.0 --set
-```
-
-Next, install Google's `protoc` compiler. See: https://github.com/google/proto-lens/blob/master/docs/installing-protoc.md
-
-Then install the haskell generator from the proto-lens packages:
-
-```
-cabal install proto-lens-protoc
-```
-
-Finally, generate the source files manually in `src/*`
-
-```sh
-# working directory: bindings/haskell
-protoc --plugin=protoc-gen-haskell=`which proto-lens-protoc` --haskell_out=src --proto_path=../.. scip.proto
-```
-
-Build the library as normal:
-
-```
-# working directory: bindings/haskell
-cabal build
-```
+  [SCIP]: https://github.com/scip-code/scip
+  [`scip.proto`]: https://github.com/scip-code/scip/blob/main/scip.proto
+  [`proto-lens`]: https://github.com/google/proto-lens

--- a/bindings/haskell/scip.cabal
+++ b/bindings/haskell/scip.cabal
@@ -1,23 +1,38 @@
-cabal-version:      3.6
+cabal-version:      3.12
 
 name:               scip
 version:            0.8.0
-synopsis:           Haskell bindings for SCIP Code Intelligence Protocol
+synopsis:           Haskell bindings for the SCIP code intelligence protocol
+description:
+    SCIP (pronounced "skip") is a language-agnostic protocol for
+    indexing source code, used to power code navigation functionality
+    such as go-to-definition, find-references, and find-implementations.
+    .
+    This package provides Haskell bindings generated from the SCIP
+    protobuf schema via @proto-lens@.
 license:            Apache-2.0
 license-file:       LICENSE
 author:             SCIP Maintainers
 maintainer:         code-intel@sourcegraph.com
 homepage:           https://github.com/scip-code/scip
+bug-reports:        https://github.com/scip-code/scip/issues
 category:           Language
 build-type:         Simple
+extra-doc-files:    README.md
+tested-with:        GHC == 9.10.3
+
+source-repository head
+    type:     git
+    location: https://github.com/scip-code/scip.git
+    subdir:   bindings/haskell
 
 library
-    ghc-options: -Wall
+    ghc-options:      -Wall
     exposed-modules:
         Proto.Scip,
         Proto.Scip_Fields
     hs-source-dirs:   src
-    default-language: Haskell2010
+    default-language: GHC2024
     build-depends:
         proto-lens-runtime ^>= 0.7.0.0,
-        base >= 4.14.0.0
+        base               >= 4.20 && < 5

--- a/checks.nix
+++ b/checks.nix
@@ -67,11 +67,14 @@
     assert pkgs.lib.assertMsg (
       cabal.version == version
     ) "Version mismatch in bindings/haskell/scip.cabal: expected ${version}, got ${cabal.version}";
-    cabal.overrideAttrs {
+    cabal.overrideAttrs (oldAttrs: {
       prePatch = ''
         cp --remove-destination ${./LICENSE} LICENSE
       '';
-    };
+      postPatch = (oldAttrs.postPatch or "") + ''
+        ${pkgs.haskellPackages.cabal-install}/bin/cabal check
+      '';
+    });
 
   reprolang =
     let


### PR DESCRIPTION
Wires up Haskell binding publication to Hackage. Adds a `publish-haskell-bindings` job to `release.yaml` (alongside the existing Rust/JVM/Go publish jobs) and prepares `bindings/haskell/scip.cabal` for Hackage with proper metadata bounds, a source-repository pointer, and `GHC2024` as the default language.

## Post-merge: claim the `scip` name on Hackage

Hackage versions are immutable — once `0.8.0` is published it can never be re-uploaded. The first publish therefore goes through the **candidate** channel so we can preview the rendered package page before committing.

From a maintainer's machine on `main`:

```sh
cd bindings/haskell
nix develop -c cabal sdist
nix develop -c cabal upload --token="$HACKAGE_TOKEN" \
    dist-newstyle/sdist/scip-0.8.0.tar.gz
```

Review the candidate at https://hackage.haskell.org/package/scip-0.8.0/candidate — verify the rendered README, that the source-repository link targets `bindings/haskell`, the license is detected as Apache-2.0, and the dependency bounds look right.

When satisfied, publish:

```sh
nix develop -c cabal upload --publish --token="$HACKAGE_TOKEN" \
    dist-newstyle/sdist/scip-0.8.0.tar.gz
```

(Or click **Publish candidate** on the Hackage UI.)

This claims the `scip` name for the Hackage account behind `HACKAGE_TOKEN` and seeds the maintainer group with that account. From the next release onwards the workflow handles publication automatically.
