### PR TITLE
Constrain Renovate for JVM bindings deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,12 @@
       "matchManagers": ["maven"],
       "matchPackageNames": ["com.google.protobuf:*"],
       "enabled": false
+    },
+    {
+      "description": "Stay on Kotlin 2.0.x to keep the consumer floor low.",
+      "matchManagers": ["maven"],
+      "matchPackageNames": ["org.jetbrains.kotlin:*"],
+      "allowedVersions": "<2.1.0"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,5 +7,13 @@
   ],
   "nix": {
     "enabled": true
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Bump manually in lock-step with flake.nix's protoc.",
+      "matchManagers": ["maven"],
+      "matchPackageNames": ["com.google.protobuf:*"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Disable auto-bumps for `com.google.protobuf:*` — the runtime in the pom must stay in lock-step with the `protoc` pinned in [flake.nix](flake.nix), which Renovate can't see. Pin `org.jetbrains.kotlin:*` to `<2.1.0` so `scip-kotlin-bindings` keeps a low consumer floor; upstream `protobuf-kotlin` itself only targets `kotlin-stdlib:1.6.0`. Supersedes #426 and #427.