### PR TITLE
Lower cabal-version to 3.6 and default-language to GHC2021

### DIFF
--- a/bindings/haskell/scip.cabal
+++ b/bindings/haskell/scip.cabal
@@ -1,4 +1,4 @@
-cabal-version:      3.12
+cabal-version:      3.6
 
 name:               scip
 version:            0.8.0
@@ -32,7 +32,7 @@ library
         Proto.Scip,
         Proto.Scip_Fields
     hs-source-dirs:   src
-    default-language: GHC2024
+    default-language: GHC2021
     build-depends:
         proto-lens-runtime ^>= 0.7.0.0,
         base               >= 4.20 && < 5


### PR DESCRIPTION
Hackage's build matrix tries `scip-0.8.0` on GHC 9.8.4 and fails before reaching compilation:

```
rejecting: scip-0.8.0 (unsupported spec-version 3.12)
```

GHC 9.8.x ships with `Cabal-3.10.x`, which understands `cabal-version` only up to `3.10`. The previous `cabal-version: 3.12` was required by `default-language: GHC2024` (the `GHC2024` token was added in Cabal 3.12).

Lowering both to the minimum that still supports our usage:

- `cabal-version: 3.6` — minimum version that recognizes `default-language: GHC2021`
- `default-language: GHC2021` — supported by GHC 9.2+ and any Cabal ≥ 3.6

No source changes needed: the proto-lens-generated modules build cleanly under `GHC2021`. `cabal check` and `cabal build` both pass locally.

This will ship with the next release; the failed `scip-0.8.0` build reports on Hackage are cosmetic (users on GHC 9.10+ install fine), so no `0.8.0` revision is planned.
