### PR TITLE
Count proto-review author as self-review

### DIFF
--- a/.github/workflows/proto-review.yaml
+++ b/.github/workflows/proto-review.yaml
@@ -23,6 +23,9 @@ jobs:
                 - scip.proto
               teams:
                 - all-of:
-                    - '@jupblb'
-                    - '@CatherineGasnier'
-                    - '@jamydev'
+                    - is-author-or-reviewer:
+                        - '@jupblb'
+                    - is-author-or-reviewer:
+                        - '@CatherineGasnier'
+                    - is-author-or-reviewer:
+                        - '@jamydev'


### PR DESCRIPTION
The `SCIP CSC` requirement listed every reviewer in an `all-of`, including the PR author—who can't approve their own PR—so `Required review` was stuck pending. Wrapping each member in `is-author-or-reviewer` lets the author's slot count as self-reviewed while the others must still approve.