### PR TITLE
Run `proto-review` on `pull_request_target` so forks get a write token

### DIFF
--- a/.github/workflows/proto-review.yaml
+++ b/.github/workflows/proto-review.yaml
@@ -11,7 +11,9 @@ permissions:
 
 jobs:
   proto-review:
-    # `pull_request_review` is still read-only on forks
+    # `pull_request_review` is read-only on forks; otherwise the workflow would
+    # use a GitHub token without the necessary permissions. Restart the failed
+    # workflow once all approvals are gathered.
     if: >-
       github.event_name == 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/proto-review.yaml
+++ b/.github/workflows/proto-review.yaml
@@ -1,7 +1,7 @@
 name: SCIP protocol review
 
 on:
-  pull_request:
+  pull_request_target:
     paths: [scip.proto]
   pull_request_review:
 
@@ -11,6 +11,10 @@ permissions:
 
 jobs:
   proto-review:
+    # `pull_request_review` is still read-only on forks
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: Automattic/action-required-review@v5


### PR DESCRIPTION
Otherwise the workflow fails, like in this case: https://github.com/scip-code/scip/actions/runs/27570851404/job/81506666568?pr=441