### PR TITLE
Make snapshot files not executable

### DIFF
--- a/bindings/go/scip/testutil/snapshot_testing.go
+++ b/bindings/go/scip/testutil/snapshot_testing.go
@@ -63,7 +63,7 @@ func snapshotTestSources(t *testing.T, outputDirectory string, obtainedSnapshots
 			if *updateSnapshots {
 				err = os.MkdirAll(filepath.Dir(outputFile), 0755)
 				require.Nil(t, err)
-				err = os.WriteFile(outputFile, []byte(obtained), 0755)
+				err = os.WriteFile(outputFile, []byte(obtained), 0644)
 				require.Nil(t, err)
 			} else {
 				edits := myers.ComputeEdits(span.URIFromPath(outputFile), string(expected), obtained)

--- a/cmd/scip/snapshot.go
+++ b/cmd/scip/snapshot.go
@@ -86,7 +86,7 @@ func snapshotMain(flags snapshotFlags) error {
 		if err != nil {
 			return err
 		}
-		err = os.WriteFile(outputPath, []byte(snapshot.Text), 0755)
+		err = os.WriteFile(outputPath, []byte(snapshot.Text), 0644)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Snapshot output files are golden text fixtures, not executables. Writing them `0755` set the executable bit unnecessarily and made git record them as mode `100755`. Switch the file mode to `0644` in both `scip snapshot` and the `-update-snapshots` test helper (directory `MkdirAll` modes are unchanged).