### PR TITLE
Add scip-cli to tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For more details about indexers,
 see the [Sourcegraph documentation](https://docs.sourcegraph.com/code_navigation/references/indexers).
 
 Other tools which use SCIP include the [Sourcegraph CLI](https://github.com/sourcegraph/src-cli),
-and the SCIP CLI in this repo.
+the SCIP CLI in this repo, and [scip-cli](https://github.com/flesler/scip-cli) — a fast Python CLI for querying SCIP indexes via SQLite.
 
 ## Installing the `scip` CLI
 


### PR DESCRIPTION
Add [scip-cli](https://github.com/flesler/scip-cli) to the existing tools list in the README.

scip-cli is a Python CLI that builds on top of the `scip` binary from this repo (uses `scip expt-convert` for index conversion). It provides a token-efficient query interface and `analyze` command for AI agents — zero overlap with the core `scip` CLI, purely complementary.